### PR TITLE
Adding 'type' param to query, currently only supports ask

### DIFF
--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -505,11 +505,17 @@
 (defn create-query 
   "Return parsed query object. If query is not a string, assume object that can
 use io/slurp"
-  [query-source]
-  (if  (vector? query-source)
-    (->StoredQuery (OpAsQuery/asQuery (op query-source)))
-    (let [query-str (if (string? query-source) query-source (slurp query-source))]
-      (->StoredQuery (QueryFactory/create (expand-query-str query-str))))))
+  ([query-source] (create-query query-source {}))
+  ([query-source params]
+   (let [query (if  (vector? query-source)
+                  (OpAsQuery/asQuery (op query-source))
+                  (QueryFactory/create (expand-query-str
+                                        (if (string? query-source)
+                                          query-source
+                                          (slurp query-source)))))]
+     (when (= :ask (::type params))
+       (.setQueryAskType query))
+     (->StoredQuery query))))
 
 (defmacro declare-query [& queries]
   (let [root# (-> *ns* str (s/replace #"\." "/") (s/replace #"-" "_") (str "/"))]

--- a/test/genegraph/query/query_test.clj
+++ b/test/genegraph/query/query_test.clj
@@ -21,6 +21,9 @@
   (let [q (create-query "ask { ?x a :owl/Class }")]
     (is (= true (q)))))
 
+(deftest test-ask-with-algebra
+  (let [q (create-query '[:bgp [x :rdf/type :owl/Class]] {::q/type :ask})]
+    (is (= true (q)))))
 
 (def union-sample (statements-to-model [["http://test/report1" :rdf/type :sepio/GeneDosageReport]
                                         ["http://test/report2" :rdf/type :sepio/GeneValidityReport]


### PR DESCRIPTION
This is necessary to specify the type of query to execute when a query
is defined by algebra alone; otherwise it seems to default to select,
and query type is not inferred from the algebra itself, at least not
for ask. This makes it possible to construct an ask query using just algebra.