### PR TITLE
Graphql add genetic condition

### DIFF
--- a/resources/class-names.edn
+++ b/resources/class-names.edn
@@ -10,6 +10,7 @@
  [:sepio/GeneticCondition "http://purl.obolibrary.org/obo/SEPIO_0000219"]
  [:sepio/EvidenceRole "http://purl.obolibrary.org/obo/SEPIO_0000148"]
  [:cg/DomainModel "http://dataexchange.clinicalgenome.org/terms/DomainModel"]
+ [:cg/ActionabilityGeneticCondition "http://dataexchange.clinicalgenome.org/terms/ActionabilityGeneticCondition"]
  [:so/ProteinCodingGene "http://purl.obolibrary.org/obo/SO_0001217"]
  [:so/SequenceFeature "http://purl.obolibrary.org/obo/SO_0000110"]
  [:sepio/GeneDosageReport "http://purl.obolibrary.org/obo/SEPIO_0002015"]

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -512,14 +512,15 @@
 use io/slurp"
   ([query-source] (create-query query-source {}))
   ([query-source params]
-   (let [query (if  (vector? query-source)
+   (let [query (if  (coll? query-source)
                   (OpAsQuery/asQuery (op query-source))
                   (QueryFactory/create (expand-query-str
                                         (if (string? query-source)
                                           query-source
                                           (slurp query-source)))))]
-     (when (= :ask (::type params))
-       (.setQueryAskType query))
+     (case (::type params)
+       :ask (.setQueryAskType query)
+       (.setDistinct query true))
      (->StoredQuery query))))
 
 (defmacro declare-query [& queries]

--- a/src/genegraph/source/graphql/common/curation.clj
+++ b/src/genegraph/source/graphql/common/curation.clj
@@ -1,0 +1,27 @@
+(ns genegraph.source.graphql.common.curation
+  (:require [genegraph.database.query :as q :refer [create-query]]))
+
+
+(def gene-validity-bgp
+  '[[validity_proposition :sepio/has-subject gene]
+    [validity_proposition :sepio/has-object disease]
+    [validity_proposition :rdf/type :sepio/GeneValidityProposition]])
+
+(def actionability-bgp
+  '[[actionability_genetic_condition :sepio/is-about-gene gene]
+    [ac_proposition :sepio/is-about-condition actionability_genetic_condition]
+    [ac_proposition :rdf/type :sepio/ActionabilityReport]
+    [actionability_genetic_condition :owl/sub-class-of disease]])
+
+(def gene-dosage-bgp
+  '[[dosage_report :iao/is-about gene]
+    [dosage_report :rdf/type :sepio/GeneDosageReport]])
+
+(def gene-dosage-disease-bgp 
+  '[[dosage_assertion :rdf/type :sepio/EvidenceLevelAssertion]
+    [dosage_assertion :sepio/has-subject dosage_proposition]
+    [dosage_proposition :sepio/has-subject copy_number]
+    [dosage_proposition :sepio/has-object disease]
+    [copy_number :geno/has-location gene]])
+
+

--- a/src/genegraph/source/graphql/common/curation.clj
+++ b/src/genegraph/source/graphql/common/curation.clj
@@ -1,7 +1,6 @@
 (ns genegraph.source.graphql.common.curation
   (:require [genegraph.database.query :as q :refer [create-query]]))
 
-
 (def gene-validity-bgp
   '[[validity_proposition :sepio/has-subject gene]
     [validity_proposition :sepio/has-object disease]
@@ -9,19 +8,70 @@
 
 (def actionability-bgp
   '[[actionability_genetic_condition :sepio/is-about-gene gene]
-    [ac_proposition :sepio/is-about-condition actionability_genetic_condition]
-    [ac_proposition :rdf/type :sepio/ActionabilityReport]
-    [actionability_genetic_condition :owl/sub-class-of disease]])
+    [ac_report :sepio/is-about-condition actionability_genetic_condition]
+    [ac_report :rdf/type :sepio/ActionabilityReport]
+    [actionability_genetic_condition :rdfs/sub-class-of disease]])
 
 (def gene-dosage-bgp
   '[[dosage_report :iao/is-about gene]
     [dosage_report :rdf/type :sepio/GeneDosageReport]])
 
-(def gene-dosage-disease-bgp 
-  '[[dosage_assertion :rdf/type :sepio/EvidenceLevelAssertion]
-    [dosage_assertion :sepio/has-subject dosage_proposition]
-    [dosage_proposition :sepio/has-subject copy_number]
-    [dosage_proposition :sepio/has-object disease]
-    [copy_number :geno/has-location gene]])
+(def gene-dosage-disease-bgp
+  (conj gene-dosage-bgp
+        '[dosage_report :bfo/has-part dosage_assertion]
+        '[dosage_assertion :sepio/has-subject dosage_proposition]
+        '[dosage_proposition :sepio/has-object omim_disease]
+        '[disease :owl/equivalent-class omim_disease]
+        ;; label filter included to remove non-mondo diseases
+        ;; bit of a hack; should probably restructure dosage import to use mondo
+        ;; condition instead of OMIM
+        '[disease :rdfs/label disease_label]))
 
+(def curation-bgps
+  [gene-validity-bgp
+   actionability-bgp
+   gene-dosage-disease-bgp])
+
+(def pattern-curation-activities
+  [[gene-validity-bgp :GENE_VALIDITY]
+   [actionability-bgp :ACTIONABILITY]
+   ;; [gene-dosage-disease-bgp :GENE_DOSAGE] ;; omitting due to poor performance
+   [gene-dosage-bgp :GENE_DOSAGE]])
+
+(def test-resource-for-activity
+  (map (fn [[pattern activity]]
+         [(create-query (cons :bgp pattern) {::q/type :ask}) activity])
+       pattern-curation-activities))
+
+(defn activities [query-params]
+  (reduce (fn [acc [test activity]] 
+            (if (test query-params) 
+              (conj acc activity)
+              acc))
+          #{}
+          test-resource-for-activity))
+
+(def union-of-all-curations
+  (cons :union (map #(cons :bgp %) curation-bgps)))
+
+(def actionability-curations-for-genetic-condition
+  (create-query [:project ['ac_report]
+                 (cons :bgp actionability-bgp)]))
+
+(def gene-validity-curations-for-genetic-condition
+  (create-query [:project ['validity_assertion]
+                 (cons :bgp (conj gene-validity-bgp
+                                  ['validity_assertion :sepio/has-object 'validity_proposition]))]))
+
+(def dosage-sensitivity-curations-for-genetic-condition
+  (create-query [:project ['dosage_assertion]
+                 (cons :bgp gene-dosage-disease-bgp)]))
+
+(def curated-diseases-for-gene
+  (create-query [:project ['disease]
+                 union-of-all-curations]))
+
+(defn curated-genetic-conditions-for-gene [query-params]
+  (map #(array-map :gene (:gene query-params) :disease %) 
+       (curated-diseases-for-gene query-params)))
 

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -25,6 +25,9 @@
     {:description "The curation activities within ClinGen. Each curation is associated with a curation activity."
      :values [:ALL :ACTIONABILITY :GENE_VALIDITY :GENE_DOSAGE]
      }
+    :ModeOfInheritance
+    {:description "Mode of inheritance for a genetic condition."
+     :values [:AUTOSOMAL_DOMINANT :AUTOSOMAL_RECESSIVE :X_LINKED :SEMIDOMINANT]}
     :GeneDosageScore
     {:description "The score assigned to a Gene Dosage curation."
      :values [:ASSOCIATED_WITH_AUTOSOMAL_RECESSIVE_PHENOTYPE
@@ -111,7 +114,7 @@
                                     :resolve gene/curation-activities}
               :curations {:type '(list :Curation)
                           :resolve gene/curations}
-              :conditions {:type '(list :Condition)
+              :conditions {:type '(list :GeneticCondition)
                            :resolve gene/conditions
                            :description "Genetic conditions associated with gene. This field is most frequently used for accessing actionability curations linked to a gene."}
               :actionability_curations {:type '(list :ActionabilityCuration)
@@ -120,6 +123,15 @@
               :dosage_curation {:type :GeneDosageCuration
                                 :resolve gene/dosage-curation
                                 :description "Gene Dosage curation associated with the gene or region."}}}
+
+    :GeneticCondition
+    {:description "A condition described by some combination of gene, disease, and mode of inheritance (usually at least gene and disease)."
+     :fields {:gene {:type :Gene}
+              :disease {:type :Disease}
+              :mode_of_inheritance {:type :ModeOfInheritance}
+              :actionability_curations {:type '(list :ActionabilityCuration)}
+              :gene_validity_curations {:type '(list :GeneValidityCuration)}
+              :gene_dosage_curations {:type '(list :GeneDosageCuration)}}}
 
     :Coordinate
     {:description "a genomic coordinate"
@@ -193,7 +205,7 @@
                             :resolve region-feature/coordinates
                             :description "Coordinates of the feature"}}}
 
-    :Condition
+    :Disease
     {:description "A disease or condition. May be a genetic condition, linked to a specific disease or mode of inheritance. Along with gene, one of the basic units of curation."
      :implements [:Resource]
      :fields {:iri {:type 'String
@@ -208,7 +220,7 @@
               :actionability_curations {:type '(list :ActionabilityCuration)
                                         :resolve condition/actionability-curations
                                         :description "Actionability curations associated with the condition"}
-              :genetic_conditions {:type '(list :Condition)
+              :genetic_conditions {:type '(list :Disease)
                                    :resolve condition/genetic-conditions
                                    :description "Genetic conditions that are direct subclasses of this condition."}}}
 
@@ -306,7 +318,7 @@
       :wg_label {:type 'String :resolve actionability/wg-label}
       :report_id {:type 'String :resolve actionability/report-id}
       :classification_description {:type 'String :resolve actionability/classification-description}
-      :conditions {:type '(list :Condition)
+      :conditions {:type '(list :Disease)
                    :resolve actionability/conditions}
       :source {:type 'String :resolve actionability/source}}}
 
@@ -434,7 +446,7 @@
                                        (str "Limit genes returned to those that have a curation, "
                                             "or a curation of a specific type.")}}
                 :resolve gene/gene-list}
-    :condition {:type '(non-null :Condition)
+    :condition {:type '(non-null :Disease)
                 :args {:iri {:type 'String}}
                 :resolve condition/condition-query}
     :actionability {:type '(non-null :ActionabilityCuration)

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -15,6 +15,7 @@
             [genegraph.source.graphql.value-set :as value-set]
             [genegraph.source.graphql.class :as rdf-class]
             [genegraph.source.graphql.property :as property]
+            [genegraph.source.graphql.genetic-condition :as genetic-condition]
             [com.walmartlabs.lacinia :as lacinia]
             [com.walmartlabs.lacinia.schema :as schema]
             [com.walmartlabs.lacinia.util :as util]))
@@ -126,12 +127,24 @@
 
     :GeneticCondition
     {:description "A condition described by some combination of gene, disease, and mode of inheritance (usually at least gene and disease)."
-     :fields {:gene {:type :Gene}
-              :disease {:type :Disease}
-              :mode_of_inheritance {:type :ModeOfInheritance}
-              :actionability_curations {:type '(list :ActionabilityCuration)}
-              :gene_validity_curations {:type '(list :GeneValidityCuration)}
-              :gene_dosage_curations {:type '(list :GeneDosageCuration)}}}
+     :fields {:gene {:type :Gene
+                     :resolve genetic-condition/gene
+                     :description "The gene associated with this genetic condition."}
+              :disease {:type :Disease
+                        :resolve genetic-condition/disease
+                        :description "The disease associated with this genetic condition."}
+              :mode_of_inheritance {:type :ModeOfInheritance
+                                    :resolve genetic-condition/mode-of-inheritance
+                                    :description "The mode of inheritance associated with this genetic condition."}
+              :actionability_curation {:type :ActionabilityCuration
+                                       :resolve genetic-condition/actionability-curation
+                                       :description "Actionability curation associated with this genetic condition."}
+              :gene_validity_curation {:type :GeneValidityCuration
+                                       :resolve genetic-condition/gene-validity-curation
+                                       :description "Gene Validity curation associated with this genetic condition."}
+              :gene_dosage_curation {:type :DosageAssertion
+                                     :resolve genetic-condition/gene-dosage-curation
+                                     :description "Dosage sensitivity curation associated with this genetic condition."}}}
 
     :Coordinate
     {:description "a genomic coordinate"
@@ -298,7 +311,7 @@
               :evidence {:type '(list :Evidence)
                          :resolve dosage-proposition/evidence
                          :description "Evidence relating to the gene dosage curation."}
-              :score {:type 'Int
+              :score {:type :GeneDosageScore
                       :resolve dosage-proposition/score
                       :description "Sufficiency score"}
               :phenotypes {:type 'String

--- a/src/genegraph/source/graphql/gene.clj
+++ b/src/genegraph/source/graphql/gene.clj
@@ -12,41 +12,19 @@
        gene
        (first (filter #(q/is-rdf-type? % :so/ProteinCodingGene) (get gene [:owl/same-as :<]))))))
 
-(def has-validity-bgp '[[validity_prop :sepio/has-subject gene]
-                        [validity_prop :rdf/type :sepio/GeneValidityProposition]])
-
-(def has-actionability-bgp '[[actionability_genetic_condition :sepio/is-about-gene gene]
-                             [ac_prop :sepio/is-about-condition actionability_genetic_condition]
-                             [ac_prop :rdf/type :sepio/ActionabilityReport]])
-
-(def has-dosage-bgp '[[dosage_report :iao/is-about gene]
-                      [dosage_report :rdf/type :sepio/GeneDosageReport]])
-
-
-;; Internal actionability bnodes do not carry type :owl/Class
-(def actionability-disease-gc-bgp
-  '[[genetic_condition :sepio/is-about-gene gene]
-    [ac_prop :sepio/is-about-condition disease]
-    [disease :rdf/type :owl/Class]
-    [ac_prop :rdf/type :sepio/ActionabilityReport]])
-
-;; Probably need to add a little more structure to 
-;; actionability curation import for this.
-(def actionability-disease-bgp has-actionability-bgp)
-
 (defn gene-list [context args value]
   (let [params (-> args (select-keys [:limit :offset]) (assoc :distinct true))
         base-bgp '[[gene :rdf/type :so/ProteinCodingGene]]
         selected-curation-type-bgp (case (:curation_type args)
-                                     :GENE_VALIDITY has-validity-bgp
-                                     :ACTIONABILITY has-actionability-bgp
-                                     :GENE_DOSAGE has-dosage-bgp
+                                     :GENE_VALIDITY curation/gene-validity-bgp
+                                     :ACTIONABILITY curation/actionability-bgp
+                                     :GENE_DOSAGE curation/gene-dosage-bgp
                                      [])
         bgp (if (= :ALL (:curation_type args))
               [:union 
-               (cons :bgp (concat base-bgp has-validity-bgp))
-               (cons :bgp (concat base-bgp has-actionability-bgp))
-               (cons :bgp (concat base-bgp has-dosage-bgp))]
+               (cons :bgp (concat base-bgp curation/gene-validity-bgp))
+               (cons :bgp (concat base-bgp curation/actionability-bgp))
+               (cons :bgp (concat base-bgp curation/gene-dosage-bgp))]
               (cons :bgp
                     (concat base-bgp
                             selected-curation-type-bgp)))
@@ -57,14 +35,7 @@
     (query {::q/params params})))
 
 (defn curation-activities [context args value]
-  (reduce (fn [acc tuple] 
-            (if ((create-query (into [] (cons :bgp (first tuple))) {::q/type :ask}) {:gene value})
-              (conj acc (second tuple))
-              acc))
-          []
-          [[has-validity-bgp :GENE_VALIDITY]
-           [has-actionability-bgp :ACTIONABILITY]
-           [has-dosage-bgp :GENE_DOSAGE]]))
+  (curation/activities {:gene value}))
 
 (defn last-curated-date [context args value]
   (let [curation-dates (concat (ld-> value [[:sepio/has-subject :<]
@@ -95,14 +66,14 @@
     (map #(tag-with-type % :actionability_curation)) actionability))
 
 (defn conditions [context args value]
-  (get value [:sepio/is-about-gene :<]))
+  (curation/curated-genetic-conditions-for-gene {:gene value}))
 
 ;; TODO check for type (hopefully before structurally necessary)
 (defn actionability-curations [context args value]
   (ld-> value [[:sepio/is-about-gene :<] [:sepio/is-about-condition :<]]))
 
 (defn dosage-curation [context args value]
-  (let [query (create-query [:project ['dosage_report] (cons :bgp has-dosage-bgp)])]
+  (let [query (create-query [:project ['dosage_report] (cons :bgp curation/gene-dosage-bgp)])]
     (first (query {::q/params {:limit 1} :gene value}))))
 
 (defn previous-symbols [context args value]

--- a/src/genegraph/source/graphql/gene.clj
+++ b/src/genegraph/source/graphql/gene.clj
@@ -1,6 +1,7 @@
 (ns genegraph.source.graphql.gene
   (:require [genegraph.database.query :as q :refer [declare-query create-query ld-> ld1->]]
             [com.walmartlabs.lacinia.schema :refer [tag-with-type]]
+            [genegraph.source.graphql.common.curation :as curation]
             [clojure.string :as str]))
 
 (declare-query select-gene-list)
@@ -14,12 +15,24 @@
 (def has-validity-bgp '[[validity_prop :sepio/has-subject gene]
                         [validity_prop :rdf/type :sepio/GeneValidityProposition]])
 
-(def has-actionability-bgp '[[genetic_condition :sepio/is-about-gene gene]
-                             [ac_prop :sepio/is-about-condition genetic_condition]
+(def has-actionability-bgp '[[actionability_genetic_condition :sepio/is-about-gene gene]
+                             [ac_prop :sepio/is-about-condition actionability_genetic_condition]
                              [ac_prop :rdf/type :sepio/ActionabilityReport]])
 
 (def has-dosage-bgp '[[dosage_report :iao/is-about gene]
                       [dosage_report :rdf/type :sepio/GeneDosageReport]])
+
+
+;; Internal actionability bnodes do not carry type :owl/Class
+(def actionability-disease-gc-bgp
+  '[[genetic_condition :sepio/is-about-gene gene]
+    [ac_prop :sepio/is-about-condition disease]
+    [disease :rdf/type :owl/Class]
+    [ac_prop :rdf/type :sepio/ActionabilityReport]])
+
+;; Probably need to add a little more structure to 
+;; actionability curation import for this.
+(def actionability-disease-bgp has-actionability-bgp)
 
 (defn gene-list [context args value]
   (let [params (-> args (select-keys [:limit :offset]) (assoc :distinct true))

--- a/src/genegraph/source/graphql/gene/select_genetic_conditions.sparql
+++ b/src/genegraph/source/graphql/gene/select_genetic_conditions.sparql
@@ -1,0 +1,18 @@
+# Select the conditions associated with a gene via a curation.
+
+select distinct ?disease
+where {
+  { ?validity_prop a :sepio/GeneValidityProposition ;
+    :sepio/has-subject ?gene ;
+    :sepio/has-object ?disease .
+  } union {
+    ?ac_prop a :sepio/ActionabilityReport ;
+    :sepio/is-about-condition ?ac_genetic_cond .
+    ?ac_genetic_cond :sepio/is-about-gene ?gene ;
+    a :cg/ActionabilityGeneticCondition ;
+    :owl/sub-class-of ?disease .
+  } union {
+    ?ac_prop a :sepio/ActionabilityReport ;
+    :sepio/is-about-condition
+  }
+}

--- a/src/genegraph/source/graphql/genetic_condition.clj
+++ b/src/genegraph/source/graphql/genetic_condition.clj
@@ -1,0 +1,20 @@
+(ns genegraph.source.graphql.genetic-condition
+  (:require [genegraph.source.graphql.common.curation :as curation]))
+
+(defn gene [context args value]
+  (:gene value))
+
+(defn disease [context args value]
+  (:disease value))
+
+(defn mode-of-inheritance [context args value]
+  (:mode-of-inheritance value))
+
+(defn actionability-curation [context args value]
+  (first (curation/actionability-curations-for-genetic-condition value)))
+
+(defn gene-validity-curation [context args value]
+  (first (curation/gene-validity-curations-for-genetic-condition value)))
+
+(defn gene-dosage-curation [context args value]
+  (first (curation/dosage-sensitivity-curations-for-genetic-condition value)))

--- a/src/genegraph/transform/actionability.clj
+++ b/src/genegraph/transform/actionability.clj
@@ -37,10 +37,11 @@
   (str (q/ld1-> parent-condition [:rdfs/label]) ", " (q/ld1-> gene [:skos/preferred-label])))
 
 (defn genetic-condition [curation-iri condition]
-  (when-let [condition-resource (if (re-find #"MONDO" curation-iri)
+  (when-let [condition-resource (if (re-find #"MONDO" (:iri condition))
                                   (q/resource (:iri condition))
-                                  (q/ld1-> (q/resource (:iri condition))
-                                           [[:owl/equivalent-class :<]]))]
+                                  (first (filter #(re-find #"MONDO" (str %))
+                                                 (q/ld-> (q/resource (:iri condition))
+                                                         [[:owl/equivalent-class :-]]))))]
     (let [gc-node (l/blank-node)
           gene (q/ld1-> (q/resource (:gene condition)) [[:owl/same-as :<]])]
       [[curation-iri :sepio/is-about-condition gc-node]

--- a/src/genegraph/transform/actionability.clj
+++ b/src/genegraph/transform/actionability.clj
@@ -3,24 +3,52 @@
             [genegraph.database.query :as q]
             [genegraph.transform.core :refer [transform-doc src-path]]
             [cheshire.core :as json]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [clojure.spec.alpha :as spec]))
+
+
+(spec/def :condition/iri #(or (re-matches #"http://purl\.obolibrary\.org/obo/OMIM_\d+" %)
+                              (re-matches #"http://purl\.obolibrary\.org/obo/MONDO_\d+" %)))
+
+(spec/def ::iri #(re-find #"^https://actionability\.clinicalgenome\.org/ac" %))
+
+(spec/def ::gene #(re-matches #"HGNC:\d+" %))
+
+(spec/def ::statusFlag #(#{"Released" "Released - Under Revision"} %))
+
+(spec/def ::condition
+  (spec/keys :req-un [:condition/iri ::gene]))
+
+(spec/def ::conditions
+  (spec/coll-of ::condition))
+
+(spec/def ::name string?)
+
+(spec/def ::affiliation
+  (spec/keys :req-un [::name]))
+
+(spec/def ::affiliations
+  (spec/coll-of ::affiliation))
+
+(spec/def ::curation
+  (spec/keys :req-un [::statusFlag ::conditions ::affiliations]))
 
 (defn genetic-condition-label [parent-condition gene]
   (str (q/ld1-> parent-condition [:rdfs/label]) ", " (q/ld1-> gene [:skos/preferred-label])))
 
-;; TODO Validate form of input (curation MUST have a condition, conditions MUST have a gene)
 (defn genetic-condition [curation-iri condition]
-  (when-let [condition-resource (q/ld1-> (q/resource (:iri condition)) [[:owl/equivalent-class :<]])]
-    (if (or (q/is-rdf-type? condition-resource :sepio/GeneticCondition)
-            (not (:gene condition)))
-      [[curation-iri :sepio/is-about-condition condition-resource]]
-      (let [gc-node (l/blank-node)
-            gene (q/ld1-> (q/resource (:gene condition)) [[:owl/same-as :<]])]
-        [[curation-iri :sepio/is-about-condition gc-node]
-         [gc-node :rdf/type :sepio/GeneticCondition]
-         [gc-node :rdfs/sub-class-of condition-resource]
-         [gc-node :sepio/is-about-gene gene]
-         [gc-node :rdfs/label (genetic-condition-label condition-resource gene)]]))))
+  (when-let [condition-resource (if (re-find #"MONDO" curation-iri)
+                                  (q/resource (:iri condition))
+                                  (q/ld1-> (q/resource (:iri condition))
+                                           [[:owl/equivalent-class :<]]))]
+    (let [gc-node (l/blank-node)
+          gene (q/ld1-> (q/resource (:gene condition)) [[:owl/same-as :<]])]
+      [[curation-iri :sepio/is-about-condition gc-node]
+       [gc-node :rdf/type :sepio/GeneticCondition]
+       [gc-node :rdf/type :cg/ActionabilityGeneticCondition]
+       [gc-node :rdfs/sub-class-of condition-resource]
+       [gc-node :sepio/is-about-gene gene]
+       [gc-node :rdfs/label (genetic-condition-label condition-resource gene)]])))
 
 (defn search-contributions [curation-iri search-date agent-iri]
   (let [contrib-iri (l/blank-node)]
@@ -30,20 +58,22 @@
      [contrib-iri :sepio/has-agent agent-iri]]))
 
 (defn transform [curation]
-  (let [curation-iri (:iri curation)
-        contrib-iri (l/blank-node)
-        agent-iri (l/blank-node)
-        statements (concat 
-                    [[curation-iri :rdf/type :sepio/ActionabilityReport]
-                     [curation-iri :sepio/qualified-contribution contrib-iri]
-                     [curation-iri :dc/source (:scoreDetails curation)]
-                     [contrib-iri :sepio/activity-date (:dateISO8601 curation)]
-                     [contrib-iri :bfo/realizes :sepio/ApproverRole]
-                     [contrib-iri :sepio/has-agent agent-iri]
-                     [agent-iri :rdfs/label (-> curation :affiliations first :name)]]
-                    (mapcat #(genetic-condition curation-iri %) (:conditions curation))
-                    (mapcat #(search-contributions curation-iri % agent-iri)
-                            (:searchDates curation)))]
+  (let [statements (if (spec/valid? ::curation curation)
+                     (let [curation-iri (:iri curation)
+                           contrib-iri (l/blank-node)
+                           agent-iri (l/blank-node)]
+                       (concat 
+                        [[curation-iri :rdf/type :sepio/ActionabilityReport]
+                         [curation-iri :sepio/qualified-contribution contrib-iri]
+                         [curation-iri :dc/source (:scoreDetails curation)]
+                         [contrib-iri :sepio/activity-date (:dateISO8601 curation)]
+                         [contrib-iri :bfo/realizes :sepio/ApproverRole]
+                         [contrib-iri :sepio/has-agent agent-iri]
+                         [agent-iri :rdfs/label (-> curation :affiliations first :name)]]
+                        (mapcat #(genetic-condition curation-iri %) (:conditions curation))
+                        (mapcat #(search-contributions curation-iri % agent-iri)
+                                (:searchDates curation))))
+                     [])] 
     (l/statements-to-model statements)))
 
 (defmethod transform-doc :actionability-v1 [doc-def]

--- a/src/genegraph/transform/gci_legacy.clj
+++ b/src/genegraph/transform/gci_legacy.clj
@@ -31,6 +31,7 @@
    "Limited" :sepio/LimitedEvidence
    "Moderate" :sepio/ModerateEvidence
    "No Reported Evidence" :sepio/NoEvidence
+   "No Known Disease Relationship" :sepio/NoEvidence
    "Strong*" :sepio/StrongEvidence
    "Contradictory (disputed)" :sepio/DisputingEvidence
    "Strong" :sepio/StrongEvidence
@@ -68,6 +69,7 @@
    [iri :cnt/chars (json/encode report)]])
 
 (defn gci-legacy-report-to-triples [report]
+  ;;(clojure.pprint/pprint report)
   (let [root-version (str gci-root (-> report :iri))
         iri (str root-version "-" (report-date report))
         content-id (l/blank-node)


### PR DESCRIPTION
This is a big one, unfortunately not entirely limited to one concern (mea culpa), but I cleaned up some data that made this feature otherwise difficult to implement.

Major points:
* Created a new object in GraphQL: GeneticCondition. This represents a gene, disease, and (optionally and not implemented) a mode of inheritance.
* This object does not use the usual contract for GraphQL functions, where the 'value' is always an RDFResource. Instead the value is a Clojure map with keys :gene, :disease, :mode-of-inheritance
* This allows us to avoid reifying this concept for everything in the database, which would be kind of awful. It does mean we lean on the curation BGPs to find anything linked to it, however.
* Apropos to the last point, curation BGPs have been placed in a common file (curation.clj), with convenience methods located there.
* Data cleanup included filtering Actionability curations for only good ones using Clojure.spec. There is a lot of bad data in the ACI stream; this eliminates all exceptions importing it (at least as of the present moment).