### PR TITLE
Fix for issue starting server with enum keys defined by resources

### DIFF
--- a/src/genegraph/source/graphql/common/enum.clj
+++ b/src/genegraph/source/graphql/common/enum.clj
@@ -2,9 +2,9 @@
   (:require [genegraph.database.query :refer [resource]]))
 
 (def mode-of-inheritance
-  {(resource :hpo/AutosomalDominantInheritance) :AUTOSOMAL_DOMINANT
-   (resource :hpo/AutosomalRecessiveInheritance) :AUTOSOMAL_RECESSIVE
-   (resource :hpo/XLinkedInheritance) :X_LINKED
-   (resource :hpo/SemidominantModeOfInheritance) :SEMIDOMINANT
-   (resource :hpo/MitochondrialInheritance) :MITOCHONDRIAL
-   (resource :hpo/ModeOfInheritance) :UNDETERMINED})
+  {:hpo/AutosomalDominantInheritance :AUTOSOMAL_DOMINANT
+   :hpo/AutosomalRecessiveInheritance :AUTOSOMAL_RECESSIVE
+   :hpo/XLinkedInheritance :X_LINKED
+   :hpo/SemidominantModeOfInheritance :SEMIDOMINANT
+   :hpo/MitochondrialInheritance :MITOCHONDRIAL
+   :hpo/ModeOfInheritance :UNDETERMINED})

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -6,16 +6,16 @@
   (ld1-> value [:sepio/qualified-contribution :sepio/activity-date]))
 
 (def evidence-levels
-  {(resource :sepio/DefinitiveEvidence) :DEFINITIVE
-   (resource :sepio/LimitedEvidence) :LIMITED
-   (resource :sepio/ModerateEvidence) :MODERATE
-   (resource :sepio/NoEvidence) :NO_KNOWN_DISEASE_RELATIONSHIP
-   (resource :sepio/RefutingEvidence) :REFUTED
-   (resource :sepio/DisputingEvidence) :DISPUTED
-   (resource :sepio/StrongEvidence) :STRONG})
+  {:sepio/DefinitiveEvidence :DEFINITIVE
+   :sepio/LimitedEvidence :LIMITED
+   :sepio/ModerateEvidence :MODERATE
+   :sepio/NoEvidence :NO_KNOWN_DISEASE_RELATIONSHIP
+   :sepio/RefutingEvidence :REFUTED
+   :sepio/DisputingEvidence :DISPUTED
+   :sepio/StrongEvidence :STRONG})
 
 (defn classification [context args value]
-  (-> value :sepio/has-object first evidence-levels))
+  (-> value :sepio/has-object first q/to-ref evidence-levels))
 
 (defn gene [context args value]
   (ld1-> value [:sepio/has-subject :sepio/has-subject]))
@@ -24,6 +24,8 @@
   (ld1-> value [:sepio/has-subject :sepio/has-object]))
 
 (defn mode-of-inheritance [context args value]
-  (enum/mode-of-inheritance  (ld1-> value [:sepio/has-subject :sepio/has-qualifier])))
+  (-> (ld1-> value [:sepio/has-subject :sepio/has-qualifier])  
+      q/to-ref
+      enum/mode-of-inheritance))
 
 


### PR DESCRIPTION
Bugfix--class this under the types of errors that REPL development can encourage. I wrote some code that depends on a running DB when initializing vars. This doesn't work well.  Here is the fix.