### PR TITLE
Wrap entire request in tx

### DIFF
--- a/src/genegraph/database/util.clj
+++ b/src/genegraph/database/util.clj
@@ -11,6 +11,7 @@
  (ResourceFactory/createProperty uri))
 
 (def ^:dynamic *in-tx* false)
+(def ^:dynamic *current-union-model* nil)
 
 (defmacro tx 
   "Open a read transaction on the persistent database. Most commands that read data from the databse will call this internally, since Jena TDB explicitly requires opening a transaction to read any data. If one wishes to issue multiple read commands within the scope of a single transaction, it is perfectly acceptable to wrap them all in a tx call, as this uses the var *in-tx* to ensure only a single transaction per thread is opened."
@@ -37,6 +38,12 @@
            result#)
          (catch Exception e# (log/error :fn :tx :msg e#) (.abort db))
          (finally (.end db))))))
+
+(defn begin-read-tx
+  "Open a read transaction on the persistent database and leave it open within the context of the current thread. When possible, the macro form is preferred, however this fn is available when one does not have access to the block of code to be called in the context of a transaction (i.e. in a Pedestal interceptor"
+  (.begin db ReadWrite/READ)
+  
+  ())
 
 (defmacro with-test-database 
   "Uses with-redefs to replace reference to production database with temporary,

--- a/src/genegraph/database/util.clj
+++ b/src/genegraph/database/util.clj
@@ -5,22 +5,21 @@
             [io.pedestal.log :as log])
   (:import [org.apache.jena.rdf.model ResourceFactory]
            [org.apache.jena.tdb2 TDB2Factory]
-           [org.apache.jena.query ReadWrite QueryFactory QueryExecutionFactory]))
+           [org.apache.jena.query ReadWrite QueryFactory QueryExecutionFactory Dataset]))
 
 (defn property [uri]
  (ResourceFactory/createProperty uri))
 
-(def ^:dynamic *in-tx* false)
-(def ^:dynamic *current-union-model* nil)
+(def current-union-model (atom nil))
 
 (defmacro tx 
   "Open a read transaction on the persistent database. Most commands that read data from the databse will call this internally, since Jena TDB explicitly requires opening a transaction to read any data. If one wishes to issue multiple read commands within the scope of a single transaction, it is perfectly acceptable to wrap them all in a tx call, as this uses the var *in-tx* to ensure only a single transaction per thread is opened."
   [& body]
-  `(if *in-tx*
+  `(if (.isInTransaction db) 
      (do ~@body)
-     (binding [*in-tx* true
-               *current-union-model* (.getUnionModel db)]
+     (do
        (.begin db ReadWrite/READ)
+       (reset! current-union-model (.getUnionModel db))
        (try
          (let [result# (do ~@body)]
            result#)
@@ -30,11 +29,11 @@
 (defmacro write-tx 
   "Open a write transaction on the persistent database. Will roll back in case an exception is raised, does not propagate the exception currently. Users will need to explicitly call .commit within the context of a transaction."
   [& body]
-  `(if *in-tx*
+  `(if (.isInTransaction db)
      (do ~@body)
-     (binding [*in-tx* true
-               *current-union-model* (.getUnionModel db)]
+     (do
        (.begin db ReadWrite/WRITE)
+       (reset! current-union-model (.getUnionModel db))
        (try
          (let [result# (do ~@body)]
            result#)
@@ -44,15 +43,15 @@
 (defn begin-read-tx
   "Open a read transaction on the persistent database and leave it open within the context of the current thread. When possible, the macro form is preferred, however this fn is available when one does not have access to the block of code to be called in the context of a transaction (i.e. in a Pedestal interceptor"
   []
-  (.begin db ReadWrite/READ)
-  (set! *in-tx* true)
-  (set! *current-union-model* (.getUnionModel db)))
+  (when-not (.isInTransaction db)
+    (.begin db ReadWrite/READ)
+    (reset! current-union-model (.getUnionModel db))
+    true))
 
 (defn close-read-tx
   "Close a transaction opened with begin-read-tx"
   []
-  (.end db)
-  (set! *in-tx* false))
+  (.end db))
 
 (defmacro with-test-database 
   "Uses with-redefs to replace reference to production database with temporary,

--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -78,8 +78,8 @@
 (defn service []
   (let [gql-schema (gql/schema)
         interceptors (-> (lacinia/default-interceptors gql-schema {})
-                         ;; (lacinia/inject open-tx-interceptor :before ::lacinia/query-executor)
-                         ;; (lacinia/inject close-tx-interceptor :after ::lacinia/query-executor)
+                         (lacinia/inject open-tx-interceptor :before ::lacinia/query-executor)
+                         (lacinia/inject close-tx-interceptor :after ::lacinia/query-executor)
 )]
     (merge-with into  
                 (lacinia/service-map gql-schema

--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -12,7 +12,8 @@
             [genegraph.source.graphql.gene :as gql-gene]
             [mount.core :refer [defstate]]
             [clojure.java.io :as io]
-            [clojure.edn :as edn]))
+            [clojure.edn :as edn]
+            [genegraph.database.util :refer [begin-read-tx close-read-tx]]))
 
 (defn about-page
   [request]
@@ -65,14 +66,27 @@
 ;      ["/about" {:get about-page}]]]])
 
 
+(def open-tx-interceptor
+  {:name ::open-tx
+   :enter (fn [context] (begin-read-tx) context)})
 
+(def close-tx-interceptor
+  {:name ::close-tx
+   :enter (fn [context] (close-read-tx) context)})
 
 ;;(def service (lacinia/service-map (graphql-schema) {:graphiql true}))
 (defn service []
-  (merge-with into  
-              (lacinia/service-map (gql/schema) {:graphiql true})
-              model-pages
-              {::http/host "0.0.0.0"}))
+  (let [gql-schema (gql/schema)
+        interceptors (-> (lacinia/default-interceptors gql-schema {})
+                         ;; (lacinia/inject open-tx-interceptor :before ::lacinia/query-executor)
+                         ;; (lacinia/inject close-tx-interceptor :after ::lacinia/query-executor)
+)]
+    (merge-with into  
+                (lacinia/service-map gql-schema
+                                     {:graphiql true
+                                      :interceptors interceptors})
+                model-pages
+                {::http/host "0.0.0.0"})))
 
 ;; Consumed by genegraph.server/create-server
 ;; See http/default-interceptors for additional options you can configure

--- a/src/genegraph/source/graphql/common/enum.clj
+++ b/src/genegraph/source/graphql/common/enum.clj
@@ -1,6 +1,7 @@
 (ns genegraph.source.graphql.common.enum
   (:require [genegraph.database.query :refer [resource]]))
 
+;; TODO  BROKEN--can't create resources prior to db init, need another way
 (def mode-of-inheritance
   {(resource :hpo/AutosomalDominantInheritance) :AUTOSOMAL_DOMINANT
    (resource :hpo/AutosomalRecessiveInheritance) :AUTOSOMAL_RECESSIVE


### PR DESCRIPTION
There are a few things going on here:

* We are inserting an open transaction ahead of the GraphQL query execution. This should be the only transaction opened during the lifecycle of a request.
* We are closing the transaction at the end

The above is accomplished by inserting a small interceptor before and after the actual GraphQL execution (see the code in service.clj)

Additionally, whenever a transaction is opened, a global reference to the union graph is updated; whenever it's needed (which can be pretty often), it is pulled instead of creating a new one.

There are some problems to this. There may be a small risk of subtle bugs by grabbing a newer version of the union graph that includes data not yet visible within the context of a transaction. Right now this risk seems small, but a more robust solution would involve setting thread-local global state. This is left as future work--doing this with Clojure primitives instead of binding hurts my brain a little bit. Right now the state is set via an atom--so it's truly global (but synchronized)

FWIW, these two changes together result in significantly speedier code; queries run in half the time with spot checks so far.