### PR TITLE
Updating query sort to support paramater-based sorting

### DIFF
--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -84,7 +84,9 @@
 (declare to-clj)
 
 (def query-sort-order 
-  {:asc Query/ORDER_ASCENDING
+  {:ASC Query/ORDER_ASCENDING
+   :asc Query/ORDER_ASCENDING
+   :DESC Query/ORDER_DESCENDING
    :desc Query/ORDER_DESCENDING})
 
 (defn construct-query-with-params [query query-params]
@@ -96,10 +98,10 @@
         (.setLimit modified-query (:limit params)))
       (when (:offset params)
         (.setOffset modified-query (:offset params)))
-      (when (:order-by params)
-        (let [[field direction] (:order-by params)]
-          (.addResultVar modified-query field)
-          (.addOrderBy modified-query field (query-sort-order direction))))
+      (when (:sort params)
+        (let [{:keys [field direction]} (:sort params)]
+          (.addResultVar modified-query (s/lower-case (name field)))
+          (.addOrderBy modified-query (s/lower-case (name field)) (query-sort-order direction))))
       modified-query)
     query))
 

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -54,6 +54,9 @@
      :description "Sort direction."
      :values [:ASC :DESC]
      }
+    :SortField
+    {:description "Sort fields for gene, disease lists and search results."
+     :values [:GENE_LABEL]}
     :GeneDosageSortField
     {
      :description "Gene dosage sort fields."
@@ -454,6 +457,10 @@
     {:fields
      {:build {:type :Build}
       :genomic_feature_location {:type 'String}}}
+    :Sort
+    {:fields
+     {:field {:type :SortField}
+      :direction {:type :Direction :default-value :ASC}}}
     :sort_spec
     {:fields
      {:sort_field {:type :GeneDosageSortField}
@@ -500,7 +507,11 @@
                        :curation_type {:type :CurationActivity
                                        :description 
                                        (str "Limit genes returned to those that have a curation, "
-                                            "or a curation of a specific type.")}}
+                                            "or a curation of a specific type.")}
+                       :sort {:type :SortField
+                              :description (str "Order in which to sort genes. Supported fields: "
+                                                "GENE_LABEL")
+                              :default-value {:field :GENE_LABEL :direction :ASC}}}
                 :resolve gene/gene-list}
     :condition {:type '(non-null :Disease)
                 :args {:iri {:type 'String}}

--- a/src/genegraph/source/graphql/gene.clj
+++ b/src/genegraph/source/graphql/gene.clj
@@ -11,8 +11,9 @@
        (first (filter #(q/is-rdf-type? % :so/ProteinCodingGene) (get gene [:owl/same-as :<]))))))
 
 (defn gene-list [context args value]
-  (let [params (-> args (select-keys [:limit :offset]) (assoc :distinct true))
-        base-bgp '[[gene :rdf/type :so/ProteinCodingGene]]
+  (let [params (-> args (select-keys [:limit :offset :sort]) (assoc :distinct true))
+        base-bgp '[[gene :rdf/type :so/ProteinCodingGene]
+                   [gene :skos/preferred-label gene_label]]
         selected-curation-type-bgp (case (:curation_type args)
                                      :GENE_VALIDITY curation/gene-validity-bgp
                                      :ACTIONABILITY curation/actionability-bgp
@@ -29,7 +30,6 @@
         query (create-query [:project 
                              ['gene]
                              bgp])]
-    
     (query {::q/params params})))
 
 (defn curation-activities [context args value]


### PR DESCRIPTION
Pretty minimal sort, but here goes:

* Modified the sort parameter for query to take a hash of :field, :direction.
* Generally am expecting kw args, am using (name kw) to convert to str.
* Added just enough to sort the gene_list by label, using this property.

Obviously more to do, but it's a start. Sorting isn't horrible performance-wise, but it's not the best. a 7ms 'grab three genes' query becomes 210ms or so, on my laptop. Probably good enough for now, especially as filters are applied to the result set, but worth keeping possible performance improvements in mind.