### PR TITLE
Gene validity list

### DIFF
--- a/src/genegraph/source/graphql/common/curation.clj
+++ b/src/genegraph/source/graphql/common/curation.clj
@@ -58,10 +58,18 @@
   (create-query [:project ['ac_report]
                  (cons :bgp actionability-bgp)]))
 
-(def gene-validity-curations-for-genetic-condition
+(def gene-validity-curations
   (create-query [:project ['validity_assertion]
-                 (cons :bgp (conj gene-validity-bgp
-                                  ['validity_assertion :sepio/has-subject 'validity_proposition]))]))
+                 ;; Adding the reference to the assertion, plus any fields likely
+                 ;; to be used as sort values
+                 (cons :bgp 
+                       (conj gene-validity-bgp
+                             ['validity_assertion :sepio/has-subject 'validity_proposition]
+                             ['gene :skos/preferred-label 'gene_label]
+                             ['disease :rdfs/label 'disease_label]
+                             ['validity_assertion :sepio/qualified-contribution 'gv_contrib]
+                             ['gv_contrib :sepio/activity-date 'report_date]
+                             ))]))
 
 (def dosage-sensitivity-curations-for-genetic-condition
   (create-query [:project ['dosage_assertion]

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -531,18 +531,27 @@
                 :args {:iri {:type 'String}}
                 :resolve condition/condition-query}
     :disease_list {:type '(list :Disease)
-                :args {:limit {:type 'Int
-                               :default-value 10
-                               :description "Number of records to return"}
-                       :offset {:type 'Int
-                                :default-value 0
-                                :description "Index to begin returning records from"}
-                       :curation_type {:type :CurationActivity
-                                       :description 
-                                       (str "Limit genes returned to those that have a curation, "
-                                            "or a curation of a specific type.")}}
-                :resolve condition/disease-list}
-
+                   :args {:limit {:type 'Int
+                                  :default-value 10
+                                  :description "Number of records to return"}
+                          :offset {:type 'Int
+                                   :default-value 0
+                                   :description "Index to begin returning records from"}
+                          :curation_type {:type :CurationActivity
+                                          :description 
+                                          (str "Limit genes returned to those that have a curation, "
+                                               "or a curation of a specific type.")}}
+                   :resolve condition/disease-list}
+    :gene_validity_list {:type '(list :GeneValidityCuration)
+                         :args {:limit {:type 'Int
+                                        :default-value 10
+                                        :description "Number of records to return"}
+                                :offset {:type 'Int
+                                         :default-value 0
+                                         :description "Index to begin returning records from"}
+                                :sort {:type :Sort
+                                       :description (str "Order in which to sort genes. "
+                                                         "Supported fields: GENE_LABEL")}}}
     :actionability {:type '(non-null :ActionabilityCuration)
                     :args {:iri {:type 'String}}
                     :resolve actionability/actionability-query}

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -56,7 +56,7 @@
      }
     :SortField
     {:description "Sort fields for gene, disease lists and search results."
-     :values [:GENE_LABEL]}
+     :values [:GENE_LABEL :DISEASE_LABEL :REPORT_DATE]}
     :GeneDosageSortField
     {
      :description "Gene dosage sort fields."
@@ -543,6 +543,7 @@
                                                "or a curation of a specific type.")}}
                    :resolve condition/disease-list}
     :gene_validity_list {:type '(list :GeneValidityCuration)
+                         :resolve gene-validity/gene-validity-list
                          :args {:limit {:type 'Int
                                         :default-value 10
                                         :description "Number of records to return"}

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -1,9 +1,15 @@
 (ns genegraph.source.graphql.gene-validity
   (:require [genegraph.database.query :as q :refer [ld-> ld1-> create-query resource]]
-            [genegraph.source.graphql.common.enum :as enum]))
+            [genegraph.source.graphql.common.enum :as enum]
+            [genegraph.source.graphql.common.curation :as curation]))
 
 (defn report-date [context args value]
   (ld1-> value [:sepio/qualified-contribution :sepio/activity-date]))
+
+(defn gene-validity-list [context args value]
+  (let [params (-> args (select-keys [:limit :offset :sort]) (assoc :distinct true))]
+    (curation/gene-validity-curations {::q/params params})))
+
 
 (def evidence-levels
   {:sepio/DefinitiveEvidence :DEFINITIVE

--- a/src/genegraph/source/graphql/genetic_condition.clj
+++ b/src/genegraph/source/graphql/genetic_condition.clj
@@ -14,7 +14,7 @@
   (curation/actionability-curations-for-genetic-condition value))
 
 (defn gene-validity-curation [context args value]
-  (first (curation/gene-validity-curations-for-genetic-condition value)))
+  (first (curation/gene-validity-curations value)))
 
 (defn gene-dosage-curation [context args value]
   (first (curation/dosage-sensitivity-curations-for-genetic-condition value)))


### PR DESCRIPTION
Adding gene_validity_list query

Of note is how I'm doing sorting here, there are a few assumptions baked into the code (can of course be discussed if you have any opinions.

1) by convention, the variable in the BGP matches the sort field label in the enum. This means we can pass the enum result directly into the sort hash--makes life a little easier.
2) Have left out sort by classification and SOP version. There may be some fields that have a natural sort order that is not the lexicographic ordering of their label. (though maybe we start with that for now)