### PR TITLE
Adding option to return result count to query

### DIFF
--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -504,7 +504,9 @@
      (with-open [qexec (QueryExecutionFactory/create query model qs-map)]
        (cond 
          (.isConstructType query) (.execConstruct qexec)
-         (.isSelectType query) (compose-select-result qexec model)
+         (.isSelectType query) (if (= :count (get-in params [::params :type]))
+                                 (-> qexec .execSelect iterator-seq count)
+                                 (compose-select-result qexec model))
          (.isAskType query) (.execAsk qexec))))))
 
 (deftype StoredQuery [query]

--- a/test/genegraph/database/query_test.clj
+++ b/test/genegraph/database/query_test.clj
@@ -13,6 +13,11 @@
                           [:bgp [x :rdf/type :owl/Class]]])]
     (is (= 1 (count (q {::q/model sample-data}))))))
 
+(deftest test-count-query
+  (let [q (create-query '[:project [x]
+                          [:bgp [x :rdf/type :owl/Class]]])]
+    (is (= 1 (q {::q/model sample-data ::q/params {:type :count}})))))
+
 (deftest test-string-query
   (let [result (select "select ?x where { ?x a :owl/Class } " {::q/model sample-data})]
     (is (= 1 (count result)))))


### PR DESCRIPTION
Added feature to query execution to permit passing an option of :type :count, which alters the execution of a query to return a count of selected objects, rather than a collection of RDFResources.

While planning this feature I'd written the following notes, including in the PR documentation for posterity:

* Discussion

In SPARQL, the default behavior of SELECT is to project the results into a tabular format. We've intercepted and hijacked this somewhat to assume that the return is a list of Resources (at least in the first column, ignoring the rest), and to project that into our own datatype from which additional computation can be performed.

That said, sometimes you don't want a resource--you want a count of query results (as a plain integer, thanks), or a grouped, aggregate result (most likely as a map keyed by your 'group-by' parameter).

The basic use case for this would be to take a 'normal' query and return a count of results. What counts as normal? Is it a defined query object, or a BGP? where do bindings get applied? do we layer this on as a maniuplation of the algebra (i.e., wrap query X with a count statement)? If so, what does that look like? There are several choices. They are not mutually exclusive, but at some point one has to decide what one wants

** Wrap existing query in count macro

** Pass type:count on query definition

** Pass type:count on query execution

** Just use clojure count on query result

Performance is likely to be terrible--can always check and see...

(time (count (select "select ?x where {?x a :so/ProteinCodingGene }")))
"Elapsed time: 177.543523 msecs"

* Performance evaluation

Naive clojure count sucks, as expected, 178 ms for a gene count
(time (count (select "select ?x where {?x a :so/ProteinCodingGene }")))

Using count aggregate is much better, as expected: "Elapsed time: 32.846716 msecs"
(time (-> "select (count(*) as ?gene_count) where { ?x a <http://purl.obolibrary.org/obo/SO_0001217> }" QueryFactory/create (QueryExecutionFactory/create (get-all-graphs)) .execSelect iterator-seq first))

Weirdly, using clojure count on the raw iterator from a query is actually slightly better
(time (-> "select ?x where { ?x a <http://purl.obolibrary.org/obo/SO_0001217> }" QueryFactory/create (QueryExecutionFactory/create (get-all-graphs)) .execSelect iterator-seq count))
"Elapsed time: 27.868408 msecs"

This suggests modifying the query execution to return a count will offer the best performance. Conveniently this option is flexible and easy to implement. 

* Results

This strategy was fast to implement, results are decent, but somewhat worse than testing might otherwise suggest:

(def saved-query (create-query "select ?x where { ?x a :so/ProteinCodingGene }"))
(time (saved-query {::params {:type :count}}))
"Elapsed time: 62.4744 msecs"
19218

* Conclusion

This seems good enough for now--may want to consider revisiting after aggregate counts are in place


