### PR TITLE
Iri and curie for curations

### DIFF
--- a/resources/namespaces.edn
+++ b/resources/namespaces.edn
@@ -48,6 +48,11 @@
  "pubmed" "https://www.ncbi.nlm.nih.gov/pubmed/"
  "text" "http://jena.apache.org/text#"
  "uberon" "http://purl.obolibrary.org/obo/uberon/core#"
- "gci" "http://gci.clinicalgenome.org/"}
+ "gci" "http://gci.clinicalgenome.org/"
+ "cggciex" "http://dataexchange.clinicalgenome.org/gci-express/"
+ "cggv" "http://dataexchange.clinicalgenome.org/gci/"
+ "cgacta" "https://actionability.clinicalgenome.org/ac/Adult/api/sepio/doc/"
+ "cgactp" "https://actionability.clinicalgenome.org/ac/Pediatric/api/sepio/doc/"
+ "cgdosage" "http://dx.clinicalgenome.org/entities/"}
 
 

--- a/resources/property-names.edn
+++ b/resources/property-names.edn
@@ -208,7 +208,7 @@
   "http://purl.org/ontology/bibo/doi"]
  [:cg/is-in-model
   "http://dataexchange.clinicalgenome.org/terms/is_in_model"]
- [:cg/resource "http://dataexchange.clinicalgenome.org/terms/resource"]
+ [:cg/resource "http://dataexchange.clinicalgenome.org/terms/resourceProps"]
  [:cg/genes "http://dataexchange.clinicalgenome.org/terms/genes"]
  [:cg/diseases "http://dataexchange.clinicalgenome.org/terms/diseases"]
  [:cnt/chars "http://www.w3.org/2011/content#chars"]

--- a/resources/version.edn
+++ b/resources/version.edn
@@ -1,1 +1,1 @@
-{:migration 7}
+{:migration 8}

--- a/src/genegraph/env.clj
+++ b/src/genegraph/env.clj
@@ -1,20 +1,12 @@
 (ns genegraph.env
   (:require [io.pedestal.log :as log]))
-
 (def data-vol (System/getenv "CG_SEARCH_DATA_VOL"))
-(def dx-host (System/getenv "DATA_EXCHANGE_HOST"))
-(def dx-group (System/getenv "SERVEUR_GROUP"))
 (def dx-key-pass (System/getenv "SERVEUR_KEY_PASS"))
-(def dx-keystore (System/getenv "SERVEUR_KEYSTORE"))
 (def dx-topics (System/getenv "CG_SEARCH_TOPICS"))
-(def dx-truststore (System/getenv "SERVEUR_TRUSTSTORE"))
 (def dx-stage-jaas (System/getenv "DX_STAGE_JAAS"))
 
 (defn log-environment []
   (log/info :fn :log-environment
             :data-vol data-vol
-            :dx-host dx-host
-            :dx-group dx-group
             :dx-key-pass (true? dx-key-pass)
-            :dx-keystore dx-keystore
             :dx-topics dx-topics))

--- a/src/genegraph/source/graphql/condition.clj
+++ b/src/genegraph/source/graphql/condition.clj
@@ -121,4 +121,4 @@
                         "?s :rdfs/label ?disease_label . "
                         "FILTER (!isBlank(?s)) }"))))]
     {:disease_list (query query-params)
-     :count (query (assoc-in query-params [::q/params :type] :count))}))
+     :count (query (assoc query-params ::q/params {:type :count :distinct true}))}))

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -153,12 +153,12 @@
               :actionability_curations {:type '(list :ActionabilityCuration)
                                        :resolve genetic-condition/actionability-curations
                                        :description "Actionability curations associated with this genetic condition. Unlike gene_validity and dosage, there may be more than one per genetic condition, as the condition may be curated in both pediatric and adult contexts."}
-              :gene_validity_curation {:type :GeneValidityCuration
-                                       :resolve genetic-condition/gene-validity-curation
-                                       :description "Gene Validity curation associated with this genetic condition."}
-              :gene_dosage_assertion {:type :DosageAssertion
-                                     :resolve genetic-condition/gene-dosage-curation
-                                     :description "Dosage sensitivity curation associated with this genetic condition."}}}
+              :gene_validity_assertions {:type '(list :GeneValidityAssertion)
+                                        :resolve genetic-condition/gene-validity-curation
+                                        :description "Gene Validity curation associated with this genetic condition."}
+              :gene_dosage_assertions {:type '(list :DosageAssertion)
+                                       :resolve genetic-condition/gene-dosage-curation
+                                       :description "Dosage sensitivity curation associated with this genetic condition."}}}
 
     :Coordinate
     {:description "a genomic coordinate"
@@ -293,6 +293,9 @@
      :fields {:iri {:type 'String
                     :resolve resource/iri
                     :description "IRI for the Dosage curation."}
+              :curie {:type 'String
+                      :resolve resource/curie
+                      :description "Local identifier for the Dosage curation."}
               :label {:type 'String
                       :resolve gene-dosage/label
                       :description "Label of the Gene or Region curation."}
@@ -336,6 +339,9 @@
      :fields {:iri {:type 'String
                     :resolve resource/iri
                     :description "Identifier for the curation"}
+              :curie {:type 'String
+                      :resolve resource/curie
+                      :description "Local identifier for the curation"}
               :label {:type 'String
                       :resolve resource/label
                       :description "Curation label"}
@@ -369,6 +375,8 @@
      :fields 
      {:iri {:type 'String
             :resolve resource/iri}
+      :curie {:type 'String
+              :resolve resource/curie}
       :label {:type 'String :resolve resource/label}
       :report_date {:type 'String :resolve actionability/report-date}
       :wg_label {:type 'String :resolve actionability/wg-label}
@@ -378,13 +386,14 @@
                    :resolve actionability/conditions}
       :source {:type 'String :resolve actionability/source}}}
 
-    :GeneValidityCuration
+    :GeneValidityAssertion
     {:implements [:Resource :Curation]
      :fields
      {:iri {:type 'String
             :resolve resource/iri
             :description "IRI identifying this gene validity curation."}
       :curie {:type 'String
+              :resolve resource/curie
               :description "CURIE of the IRI identifying this gene validity curation."}
       :label {:type 'String
               :resolve resource/label
@@ -405,9 +414,9 @@
                             :description "Mode of inheritance associated with this curation"
                             :resolve gene-validity/mode-of-inheritance}}}
 
-    :GeneValidityCurations
+    :GeneValidityAssertions
     {:description "A collection of gene validity curations."
-     :fields {:curation_list {:type '(list :GeneValidityCuration)}
+     :fields {:curation_list {:type '(list :GeneValidityAssertion)}
               :count {:type 'Int}}}
 
     :Agent
@@ -559,7 +568,7 @@
                                           (str "Limit genes returned to those that have a curation, "
                                                "or a curation of a specific type.")}}
                    :resolve condition/disease-list}
-    :gene_validity_curations {:type :GeneValidityCurations
+    :gene_validity_curations {:type :GeneValidityAssertions
                               :resolve gene-validity/gene-validity-curations
                               :args {:limit {:type 'Int
                                              :default-value 10
@@ -574,7 +583,7 @@
                                      :sort {:type :Sort
                                             :description (str "Order in which to sort genes. "
                                                               "Supported fields: GENE_LABEL")}}}
-    :gene_validity_list {:type '(list :GeneValidityCuration)
+    :gene_validity_list {:type '(list :GeneValidityAssertion)
                          :deprecated "Use gene_validity_curations instead"
                          :resolve gene-validity/gene-validity-list
                          :args {:limit {:type 'Int

--- a/src/genegraph/source/graphql/gene.clj
+++ b/src/genegraph/source/graphql/gene.clj
@@ -61,8 +61,10 @@
         query (create-query [:project 
                              ['gene]
                              bgp])]
+    (println query-params)
     {:gene_list (query query-params)
-     :count (query (assoc-in query-params [::q/params :type] :count))}))
+     :count (query (assoc query-params ::q/params {:type :count :distinct true}))
+     }))
 
 (defn curation-activities [context args value]
   (curation/activities {:gene value}))

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -19,7 +19,7 @@
        :count (curation/gene-validity-curations-text-search 
                {:text (s/lower-case (:text args)) ::q/params {:type :count}})}
       {:curation_list (curation/gene-validity-curations {::q/params params})
-       :count (curation/gene-validity-curations {::q/params {:type :count}})})))
+       :count (curation/gene-validity-curations {::q/params {:type :count :distinct true}})})))
 
 
 (def evidence-levels

--- a/src/genegraph/source/graphql/genetic_condition.clj
+++ b/src/genegraph/source/graphql/genetic_condition.clj
@@ -14,7 +14,7 @@
   (curation/actionability-curations-for-genetic-condition value))
 
 (defn gene-validity-curation [context args value]
-  (first (curation/gene-validity-curations value)))
+  (curation/gene-validity-curations value))
 
 (defn gene-dosage-curation [context args value]
-  (first (curation/dosage-sensitivity-curations-for-genetic-condition value)))
+  (curation/dosage-sensitivity-curations-for-genetic-condition value))

--- a/src/genegraph/transform/gci_express.clj
+++ b/src/genegraph/transform/gci_express.clj
@@ -1,6 +1,6 @@
 (ns genegraph.transform.gci-express
   (:require [genegraph.database.load :as l]
-            [genegraph.database.query :as q]
+            [genegraph.database.query :as q :refer [resource]]
             [genegraph.transform.core :refer [transform-doc src-path]]
             [cheshire.core :as json]))
 
@@ -58,7 +58,7 @@
     :sepio/ClinGenGeneValidityEvaluationCriteriaSOP5))
 
 (defn evidence-level-assertion [report iri id]
-  (let [prop-iri (str gci-express-root "proposition_" id)
+  (let [prop-iri (resource (str gci-express-root "proposition_" id))
         contribution-iri (l/blank-node)]
     (concat [[iri :rdf/type :sepio/GeneValidityEvidenceLevelAssertion]
              [iri :sepio/has-subject prop-iri]
@@ -75,7 +75,7 @@
         id (-> report first name)
         iri (str gci-express-root "report_" id)
         content-id (l/blank-node)
-        assertion-id (str gci-express-root "assertion_" id)]
+        assertion-id (resource (str gci-express-root "assertion_" id))]
     (println iri)
     (concat [[iri :rdf/type :sepio/GeneValidityReport] 
              [iri :rdfs/label (:title content)]

--- a/src/genegraph/transform/gci_express.clj
+++ b/src/genegraph/transform/gci_express.clj
@@ -57,8 +57,8 @@
     :sepio/ClinGenGeneValidityEvaluationCriteriaSOP4
     :sepio/ClinGenGeneValidityEvaluationCriteriaSOP5))
 
-(defn evidence-level-assertion [report iri]
-  (let [prop-iri (l/blank-node)
+(defn evidence-level-assertion [report iri id]
+  (let [prop-iri (str gci-express-root "proposition_" id)
         contribution-iri (l/blank-node)]
     (concat [[iri :rdf/type :sepio/GeneValidityEvidenceLevelAssertion]
              [iri :sepio/has-subject prop-iri]
@@ -72,16 +72,16 @@
 
 (defn gci-express-report-to-triples [report]
   (let [content (second report)
-        root-version (str gci-express-root (-> report first name))
-        iri (str root-version "-" (:dateISO8601 content))
+        id (-> report first name)
+        iri (str gci-express-root "report_" id)
         content-id (l/blank-node)
-        assertion-id (l/blank-node)]
+        assertion-id (str gci-express-root "assertion_" id)]
     (println iri)
     (concat [[iri :rdf/type :sepio/GeneValidityReport] 
              [iri :rdfs/label (:title content)]
              [iri :bfo/has-part content-id]
              [iri :bfo/has-part assertion-id]]
-            (evidence-level-assertion content assertion-id)
+            (evidence-level-assertion content assertion-id id)
             (json-content-node content content-id))))
 
 (defmethod transform-doc :gci-express [doc-def]

--- a/src/genegraph/transform/gci_legacy.clj
+++ b/src/genegraph/transform/gci_legacy.clj
@@ -1,6 +1,6 @@
 (ns genegraph.transform.gci-legacy
   (:require [genegraph.database.load :as l]
-            [genegraph.database.query :as q]
+            [genegraph.database.query :as q :refer [resource]]
             [genegraph.transform.core :refer [transform-doc src-path]]
             [clojure.string :as s]
             [cheshire.core :as json]))
@@ -47,12 +47,12 @@
 
 (defn contribution [report iri]
   [[iri :bfo/realizes :sepio/ApproverRole]
-   [iri :sepio/has-agent (str affiliation-root
-                              (-> report :affiliation :id))]
+   [iri :sepio/has-agent  (resource (str affiliation-root
+                                         (-> report :affiliation :id)))]
    [iri :sepio/activity-date (report-date report)]])
 
 (defn evidence-level-assertion [report iri id]
-  (let [prop-iri (str gci-root "proposition_" id)
+  (let [prop-iri (resource (str gci-root "proposition_" id))
         contribution-iri (l/blank-node)]
     (concat [[iri :rdf/type :sepio/GeneValidityEvidenceLevelAssertion]
              [iri :sepio/has-subject prop-iri]
@@ -72,9 +72,9 @@
 (defn gci-legacy-report-to-triples [report]
   (let [root-version (str gci-root (-> report :iri))
         id (str (-> report :iri) "-" (s/replace (report-date report) #":" ""))
-        iri (str gci-root "report_" id)
+        iri (resource (str gci-root "report_" id))
         content-id (l/blank-node)
-        assertion-id (str gci-root "assertion_" id)]
+        assertion-id (resource (str gci-root "assertion_" id))]
     (println iri)
     (concat [[iri :rdf/type :sepio/GeneValidityReport] 
              [iri :rdfs/label (:title report)]

--- a/src/genegraph/transform/gci_legacy.clj
+++ b/src/genegraph/transform/gci_legacy.clj
@@ -2,6 +2,7 @@
   (:require [genegraph.database.load :as l]
             [genegraph.database.query :as q]
             [genegraph.transform.core :refer [transform-doc src-path]]
+            [clojure.string :as s]
             [cheshire.core :as json]))
 
 (def gci-root "http://dataexchange.clinicalgenome.org/gci/")
@@ -50,8 +51,8 @@
                               (-> report :affiliation :id))]
    [iri :sepio/activity-date (report-date report)]])
 
-(defn evidence-level-assertion [report iri]
-  (let [prop-iri (l/blank-node)
+(defn evidence-level-assertion [report iri id]
+  (let [prop-iri (str gci-root "proposition_" id)
         contribution-iri (l/blank-node)]
     (concat [[iri :rdf/type :sepio/GeneValidityEvidenceLevelAssertion]
              [iri :sepio/has-subject prop-iri]
@@ -70,15 +71,16 @@
 
 (defn gci-legacy-report-to-triples [report]
   (let [root-version (str gci-root (-> report :iri))
-        iri (str root-version "-" (report-date report))
+        id (str (-> report :iri) "-" (s/replace (report-date report) #":" ""))
+        iri (str gci-root "report_" id)
         content-id (l/blank-node)
-        assertion-id (l/blank-node)]
+        assertion-id (str gci-root "assertion_" id)]
     (println iri)
     (concat [[iri :rdf/type :sepio/GeneValidityReport] 
              [iri :rdfs/label (:title report)]
              [iri :bfo/has-part content-id]
              [iri :bfo/has-part assertion-id]]
-            (evidence-level-assertion report assertion-id)
+            (evidence-level-assertion report assertion-id id)
             (json-content-node report content-id)))) 
 
 


### PR DESCRIPTION
Apologies for the somewhat messy PR.

This mostly ensures that all curation artifacts that could be referenced have appropriate IRIs as well as CURIE representations.

The mess is that it addresses a couple unrelated issues as well

* There are a few remaining bugs with the text search--this addresses those
  * Count was left not working for gene lists
  * We were passing the Dataset into RDFResource as a model reference. This made property accesses problematic.
* Changed a few names in the schema
* Cleanup of unused environment variables.