### PR TITLE
Fix assembly file for index

### DIFF
--- a/src/genegraph/database/instance.clj
+++ b/src/genegraph/database/instance.clj
@@ -18,12 +18,11 @@
   the $CG_SEARCH_DATA_VOL environment variable and will use that file as the
   assembly."
   []
-  (when (not (.exists (io/as-file assembly-file-expanded)))
-    (with-open [r (clojure.java.io/reader (io/resource assembly-file))]
-      (with-open [w (clojure.java.io/writer assembly-file-expanded)]
-        (doseq [line (line-seq r)]
-          (.write w (string/replace line #"\$CG_SEARCH_DATA_VOL" env/data-vol))
-          (.newLine w)))))
+  (with-open [r (clojure.java.io/reader (io/resource assembly-file))]
+    (with-open [w (clojure.java.io/writer assembly-file-expanded)]
+      (doseq [line (line-seq r)]
+        (.write w (string/replace line #"\$CG_SEARCH_DATA_VOL" env/data-vol))
+        (.newLine w))))
   assembly-file-expanded)
 
 (defstate db

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -562,7 +562,7 @@
                                           (str "Limit genes returned to those that have a curation, "
                                                "or a curation of a specific type.")}}
                    :resolve condition/disease-list}
-    :gene_validity_curations {:type :GeneValidityAssertions
+    :gene_validity_assertions {:type :GeneValidityAssertions
                               :resolve gene-validity/gene-validity-curations
                               :args {:limit {:type 'Int
                                              :default-value 10
@@ -578,7 +578,7 @@
                                             :description (str "Order in which to sort genes. "
                                                               "Supported fields: GENE_LABEL")}}}
     :gene_validity_list {:type '(list :GeneValidityAssertion)
-                         :deprecated "Use gene_validity_curations instead"
+                         :deprecated "Use gene_validity_assertions instead"
                          :resolve gene-validity/gene-validity-list
                          :args {:limit {:type 'Int
                                         :default-value 10

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -21,6 +21,9 @@
       {:curation_list (curation/gene-validity-curations {::q/params params})
        :count (curation/gene-validity-curations {::q/params {:type :count :distinct true}})})))
 
+(defn criteria [context args value]
+  nil)
+
 
 (def evidence-levels
   {:sepio/DefinitiveEvidence :DEFINITIVE


### PR DESCRIPTION
Addresses a bug where the assembly file for the indexer was not updated after a migration.