### PR TITLE
Adding field for gene and disease to dosage assertion

### DIFF
--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -362,7 +362,13 @@
                            :description "The phenotypes to which the evidence applies"}
               :comments {:type 'String
                          :resolve dosage-proposition/comments
-                         :description "Comments related to this curation"}}}
+                         :description "Comments related to this curation"}
+              :gene {:type :Gene
+                     :resolve dosage-proposition/gene
+                     :description "Gene associated with this assertion"}
+              :disease {:type :Disease
+                     :resolve dosage-proposition/disease
+                     :description "Disease associated with this assertion"}}}
 
     :ActionabilityCuration
     {:implements [:Resource :Curation]

--- a/src/genegraph/source/graphql/dosage_proposition.clj
+++ b/src/genegraph/source/graphql/dosage_proposition.clj
@@ -35,3 +35,9 @@
 
 (defn phenotypes [context args value]
   (str/join ", " (q/ld-> value [[:sepio/has-object :>] [:owl/equivalent-class :<] :rdfs/label])))
+
+(defn gene [context args value]
+  (q/ld1-> value [:sepio/has-subject :sepio/has-subject :geno/has-location]))
+
+(defn disease [context args value]
+  (q/ld1-> value [:sepio/has-subject :sepio/has-object [:owl/equivalent-class :<]]))


### PR DESCRIPTION
Small PR, just adding a reference to the gene and the disease from dosage assertion--makes some view workflows simpler.