### PR TITLE
Deploy with prebuilt database

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.4.500"]
+                 [org.clojure/core.async "1.2.603"]
                  [io.pedestal/pedestal.service "0.5.5"]
                  [io.pedestal/pedestal.jetty "0.5.5"]
                  [hiccup "1.0.5"]
@@ -27,7 +27,6 @@
                  [com.velisco/clj-ftp "0.3.9"] ;; For downloading ftp docs
                  [clj-http "3.9.1"] ;; For downloading 
                  [com.walmartlabs/lacinia-pedestal "0.12.0"]
-                 ;; [me.raynes/fs "1.4.6"]
                  [clj-commons/fs "1.5.2"]
                  ;; Dirwatch for updating base files in development
                  [juxt/dirwatch "0.2.5"]

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,8 @@
                  [com.velisco/clj-ftp "0.3.9"] ;; For downloading ftp docs
                  [clj-http "3.9.1"] ;; For downloading 
                  [com.walmartlabs/lacinia-pedestal "0.12.0"]
-                 [me.raynes/fs "1.4.6"]
+                 ;; [me.raynes/fs "1.4.6"]
+                 [clj-commons/fs "1.5.2"]
                  ;; Dirwatch for updating base files in development
                  [juxt/dirwatch "0.2.5"]
                  ;; for generating jsonld context
@@ -41,7 +42,8 @@
                  [org.openjfx/javafx-web "11.0.1"]
                  [expound "0.7.2"]
                  [com.fasterxml.jackson.core/jackson-core "2.10.2"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.10.2"]]
+                 [com.fasterxml.jackson.core/jackson-databind "2.10.2"]
+                 [com.google.cloud/google-cloud-storage "1.108.0"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources", "jars/REBL-0.9.220.jar"]
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency

--- a/resources/version.edn
+++ b/resources/version.edn
@@ -1,1 +1,1 @@
-{:migration 8}
+{:migration 9}

--- a/src/genegraph/database/instance.clj
+++ b/src/genegraph/database/instance.clj
@@ -19,7 +19,7 @@
   assembly."
   []
   (with-open [r (clojure.java.io/reader (io/resource assembly-file))]
-    (with-open [w (clojure.java.io/writer assembly-file-expanded)]
+    (with-open [w (clojure.java.io/writer (str env/data-vol "/" assembly-file))]
       (doseq [line (line-seq r)]
         (.write w (string/replace line #"\$CG_SEARCH_DATA_VOL" env/data-vol))
         (.newLine w))))

--- a/src/genegraph/database/instance.clj
+++ b/src/genegraph/database/instance.clj
@@ -8,7 +8,7 @@
   (:import [org.apache.jena.query.text TextDatasetFactory]))
 
 (def assembly-file "genegraph-assembly.ttl")
-(def assembly-file-expanded (str env/data-vol "/" assembly-file))
+
 
 (defn get-expanded-assembly-file
   "The jena assembly file (resource/genegraph-assembly.ttl) defines where the
@@ -18,12 +18,13 @@
   the $CG_SEARCH_DATA_VOL environment variable and will use that file as the
   assembly."
   []
-  (with-open [r (clojure.java.io/reader (io/resource assembly-file))]
-    (with-open [w (clojure.java.io/writer (str env/data-vol "/" assembly-file))]
+  (let [path (str env/data-vol "/" assembly-file)]
+    (with-open [r (clojure.java.io/reader (io/resource assembly-file))
+                w (clojure.java.io/writer path)]
       (doseq [line (line-seq r)]
         (.write w (string/replace line #"\$CG_SEARCH_DATA_VOL" env/data-vol))
-        (.newLine w))))
-  assembly-file-expanded)
+        (.newLine w)))
+    path))
 
 (defstate db
   :start (TextDatasetFactory/create (get-expanded-assembly-file))

--- a/src/genegraph/env.clj
+++ b/src/genegraph/env.clj
@@ -1,6 +1,12 @@
 (ns genegraph.env
   (:require [io.pedestal.log :as log]))
-(def data-vol (System/getenv "CG_SEARCH_DATA_VOL"))
+(def base-dir (or (System/getenv "GENEGRAPH_DATA_PATH")
+                  (System/getenv "CG_SEARCH_DATA_VOL")))
+(def data-version (System/getenv "GENEGRAPH_DATA_VERSION"))
+;; May be rebound in the course of a migration
+(def ^:dynamic data-vol (if data-version
+                          (str base-dir "/" data-version)
+                          base-dir))
 (def dx-key-pass (System/getenv "SERVEUR_KEY_PASS"))
 (def dx-topics (System/getenv "CG_SEARCH_TOPICS"))
 (def dx-stage-jaas (System/getenv "DX_STAGE_JAAS"))

--- a/src/genegraph/env.clj
+++ b/src/genegraph/env.clj
@@ -10,6 +10,7 @@
 (def dx-key-pass (System/getenv "SERVEUR_KEY_PASS"))
 (def dx-topics (System/getenv "CG_SEARCH_TOPICS"))
 (def dx-stage-jaas (System/getenv "DX_STAGE_JAAS"))
+(def genegraph-bucket (System/getenv "GENEGRAPH_BUCKET"))
 
 (defn log-environment []
   (log/info :fn :log-environment

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -27,6 +27,10 @@
       (start #'db/db)
       (base/initialize-db!)
       (start #'stream/consumer-thread)
+      ;; TODO There seems to be a race condition here
+      ;; the threads shut down almost as soon as they start.
+      ;; Sleep for a couple minutes to let them warm up
+      (Thread/sleep (* 1000 60 2))
       (while (not (stream/up-to-date?))
         (Thread/sleep (* 1000 10)))
       (stop #'stream/consumer-thread)

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -49,7 +49,10 @@
   "Construct a tarball out of the given database"
   [source-dir target-archive]
   (println "Compressing database at " source-dir " to " target-archive)
-  (sh "tar" "-czf" (str target-archive ".tar.gz") "-C" source-dir "."))
+  (let [result (sh "tar" "-czf" (str target-archive ".tar.gz") "-C" source-dir ".")]
+    (if (= 0 (:exit result))
+      true
+      false)))
 
 (defn send-database
   [target-bucket database-archive database-version]
@@ -69,4 +72,5 @@
         archive-path (str database-path ".tar.gz")]
     (build-database database-path)
     (compress-database database-path archive-path)
+    (Thread/sleep 1000) ;; seems to be a race condition here to avoid
     (send-database env/genegraph-bucket archive-path version-id)))

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -49,7 +49,7 @@
   "Construct a tarball out of the given database"
   [source-dir target-archive]
   (println "Compressing database at " source-dir " to " target-archive)
-  (let [result (sh "tar" "-czf" (str target-archive ".tar.gz") "-C" source-dir ".")]
+  (let [result (sh "tar" "-czf" target-archive "-C" source-dir ".")]
     (if (= 0 (:exit result))
       true
       false)))

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -100,11 +100,12 @@
   database."
   []
   (when-not (.exists (io/file env/data-vol "tdb"))
-    (let [archive-file (str env/data-vol "/" env/data-version ".tar.gz")]
+    (let [archive-file (str env/data-version ".tar.gz")
+          archive-path (str env/data-vol "/" archive-file)]
       (fs/mkdirs env/data-vol)
       (println "retrieving " archive-file)
       (retrieve-migration env/genegraph-bucket archive-file env/data-vol)
-      (println "decompressing " archive-file)
-      (decompress-database env/data-vol archive-file))))
+      (println "decompressing " archive-path)
+      (decompress-database env/data-vol archive-path))))
 
 

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -90,6 +90,7 @@
   "After database has been downloaded, extract the tarball"
   [target-dir archive-path]
   (let [result (sh "tar" "-xzf" archive-path "-C" target-dir)]
+    (println result)
     (if (= 0 (:exit result))
       true
       false)))
@@ -99,9 +100,11 @@
   database."
   []
   (when-not (.exists (io/file env/data-vol "tdb"))
-    (let [archive-file (str env/data-version ".tar.gz")]
+    (let [archive-file (str env/data-vol "/" env/data-version ".tar.gz")]
       (fs/mkdirs env/data-vol)
       (println "retrieving " archive-file)
       (retrieve-migration env/genegraph-bucket archive-file env/data-vol)
       (println "decompressing " archive-file)
       (decompress-database env/data-vol archive-file))))
+
+

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -30,6 +30,7 @@
 (defn build-database
   "Build the Jena database and associated indexes from scratch."
   [path]
+  (println "Building database at " path)
   (with-redefs [env/data-vol path]
     (fs/mkdirs env/data-vol)
     (start #'db/db)
@@ -47,10 +48,12 @@
 (defn compress-database
   "Construct a tarball out of the given database"
   [source-dir target-archive]
+  (println "Compressing database at " source-dir " to " target-archive)
   (sh "tar" "-czf" (str target-archive ".tar.gz") "-C" source-dir "."))
 
 (defn send-database
   [target-bucket database-archive database-version]
+  (println "Sending " database-archive " to " target-bucket " with version " database-version)
   (let [gc-storage (.getService (StorageOptions/getDefaultInstance))
         blob-id (BlobId/of target-bucket (str database-version ".tar.gz"))
         blob-info (-> blob-id BlobInfo/newBuilder (.setContentType "application/gzip") .build)
@@ -66,11 +69,4 @@
         archive-path (str database-path ".tar.gz")]
     (build-database database-path)
     (compress-database database-path archive-path)
-    (send-database env/genegraph-bucket archive-path version-id))
-
-  ;; create directory
-  ;; build database
-  ;; unmount database
-  ;; create tarball
-  ;; send to GCS
-  )
+    (send-database env/genegraph-bucket archive-path version-id)))

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -104,4 +104,4 @@
       (println "retrieving " archive-file)
       (retrieve-migration env/genegraph-bucket archive-file env/data-vol)
       (println "decompressing " archive-file)
-      (decompress-database env/data-vol "/" archive-file))))
+      (decompress-database env/data-vol archive-file))))

--- a/src/genegraph/server.clj
+++ b/src/genegraph/server.clj
@@ -6,7 +6,7 @@
             [mount.core :as mount :refer [defstate]]
             [genegraph.sink.base :as base]
             [genegraph.sink.stream :as stream]
-            ;;[genegraph.migration :refer [migrate!]]
+            [genegraph.migration :as migration]
             [genegraph.env :as env]
             [io.pedestal.log :as log]))
 
@@ -44,12 +44,8 @@
   (log/info :fn :-main :message "Starting Genegraph")
   (mount.core/start #'server)
   (env/log-environment)
-  ;; (migrate!)
-  ;; It's not possible to consume messages before the base state has been loaded
-  ;; Make sure this happens first (synchronously)
-  (mount.core/start-without #'genegraph.sink.stream/consumer-thread)
-  (base/initialize-db!)
-  (reset! initialized? true)
-  (mount.core/start #'genegraph.sink.stream/consumer-thread))
+  (migration/populate-data-vol-if-needed)
+  (mount.core/start)
+  (reset! initialized? true))
 
 

--- a/src/genegraph/server.clj
+++ b/src/genegraph/server.clj
@@ -6,7 +6,7 @@
             [mount.core :as mount :refer [defstate]]
             [genegraph.sink.base :as base]
             [genegraph.sink.stream :as stream]
-            [genegraph.migration :refer [migrate!]]
+            ;;[genegraph.migration :refer [migrate!]]
             [genegraph.env :as env]
             [io.pedestal.log :as log]))
 
@@ -44,7 +44,7 @@
   (log/info :fn :-main :message "Starting Genegraph")
   (mount.core/start #'server)
   (env/log-environment)
-  (migrate!)
+  ;; (migrate!)
   ;; It's not possible to consume messages before the base state has been loaded
   ;; Make sure this happens first (synchronously)
   (mount.core/start-without #'genegraph.sink.stream/consumer-thread)

--- a/src/genegraph/sink/base.clj
+++ b/src/genegraph/sink/base.clj
@@ -24,14 +24,8 @@
 ;; TODO ensure target directory exists
 (defn target-base []
   (str env/data-vol "/base/"))
-(def base-resources-edn "base.edn")
-(defn state-file []
-  (str env/data-vol "/base_state.edn"))
 
-(defstate current-state
-  :start (if (.exists (io/as-file (state-file)))
-           (atom (-> (state-file) slurp edn/read-string))
-           (atom {})))
+(def base-resources-edn "base.edn")
 
 (defn read-edn [resource]
   (with-open [rdr (PushbackReader. (io/reader (io/resource resource)))]
@@ -40,58 +34,33 @@
 (defn read-base-resources []
   (read-edn base-resources-edn))
 
-(def base-resources (read-base-resources))
-
-(defn- update-state! [resource-name k v]
-  (swap! current-state assoc-in [resource-name k] v)
-  (spit (state-file) (prn-str @current-state)))
-
 (defn retrieve-base-data! [resources]
   (doseq [{uri-str :source, target-file :target, opts :fetch-opts, name :name} resources]
     (let [path (str (target-base) target-file)]
       (io/make-parents path)
-      (fetch/fetch-data uri-str path opts))
-    (update-state! name :retrieved (str (Instant/now)))))
+      (fetch/fetch-data uri-str path opts))))
 
 (defn import-documents! [documents]
   (doseq [d documents]
     (log/info :fn :import-documents! :msg :importing :name (:name d))
-    (db/load-model (transform-doc d) (:name d))
-    (update-state! (:name d) :imported (str (Instant/now)))))
+    (db/load-model (transform-doc d) (:name d))))
 
 (defn initialize-db! []
   (let [res (read-base-resources)]
-    
-    (->> res
-         (remove #(get-in @current-state [(:name %) :retrieved]))
-         retrieve-base-data!)
-    (->> res
-         (remove #(get-in @current-state [(:name %) :imported]))
-         import-documents!)
+    (retrieve-base-data! res)
+    (import-documents! res)
     (log/info :fn :initialize-db! :msg :initialization-complete)))
-
-(defn async-initialize-db! []
-  (.start (Thread. initialize-db!)))
 
 (defn import-document [name documents]
   (import-documents! (filter #(= name (:name %)) documents)))
-
-(defn- set-ns-prefixes []
-  (let [prefixes (read-edn "namespaces.edn")]
-    (db/set-ns-prefixes prefixes)))
 
 (defn watch-base-dir
   "Watch for changes in directory containing base files and update triplestore whenever changes are noticed. Intended for use in development"
   []
   (watch-dir 
    (fn [event]
-     (let [changed-documents (filter #(= (-> event :file .getName) (:target %)) base-resources)]
+     (let [changed-documents (filter #(= (-> event :file .getName) (:target %)) 
+                                     (read-base-resources))]
        (import-documents! changed-documents)))
    (io/file (target-base))))
 
-(defn read-actionability-curations [path]
-  (let [files (filter #(.isFile %) (-> path io/file file-seq))]
-    (doseq [f files]
-      (let [doc (-> f io/reader (json/parse-stream true))
-            doc-spec {:format :actionability-v1 :name (:iri doc) :target (.getName f)}]
-        (db/load-model (transform-doc doc-spec) (:name doc-spec))))))

--- a/src/genegraph/sink/stream.clj
+++ b/src/genegraph/sink/stream.clj
@@ -4,7 +4,7 @@
             [genegraph.env :as env]
             [clojure.java.io :as io]
             [cheshire.core :as json]
-            [mount.core :refer [defstate]]
+            [mount.core :refer [defstate start stop]]
             [clojure.edn :as edn]
             [io.pedestal.log :as log]
             [genegraph.transform.actionability]
@@ -27,6 +27,8 @@
 (def current-offsets (atom {}))
 
 (def end-offsets (atom {}))
+
+(def topic-state (atom {}))
 
 (defn document-name [doc-def model]
   (-> (q/select "select ?x where {?x a ?type}"
@@ -70,7 +72,7 @@
         end-offset-map (reduce (fn [acc [k v]]
                                  (assoc acc [(.topic k) (.partition k)] v))
                                {} kafka-end-offsets)]
-    (reset! end-offsets end-offset-map)))
+    (swap! end-offsets merge end-offset-map)))
 
 (defn import-record! [record doc-def]
   (try
@@ -117,19 +119,20 @@
   up-to-date while they are read. Terminates when the run-consumer atom returns false"
   [topic]
   (fn []
-    (let [consumer (consumer-for-topic topic)
-          tp (topic-partitions consumer topic)
-          topic-name (-> config :topics topic :name)]
-      (.assign consumer tp)
-      (doseq [part tp]
-        (if-let [offset (get @current-offsets [topic-name (.partition part)])]
-          (.seek consumer part offset)
-          (.seekToBeginning consumer [part])))
-      (read-end-offsets! consumer tp)
-      (while @run-consumer
-        (doseq [record (poll-once consumer)]
-          (import-record! record (-> config :topics topic)))
-        (update-offsets! consumer tp)))))
+    (with-open [consumer (consumer-for-topic topic)]
+      (let [tp (topic-partitions consumer topic)
+            topic-name (-> config :topics topic :name)]
+        (.assign consumer tp)
+        (doseq [part tp]
+          (if-let [offset (get @current-offsets [topic-name (.partition part)])]
+            (.seek consumer part offset)
+            (.seekToBeginning consumer [part])))
+        (read-end-offsets! consumer tp)
+        (while @run-consumer
+          (doseq [record (poll-once consumer)]
+            (import-record! record (-> config :topics topic)))
+          (update-offsets! consumer tp))
+        (swap! topic-state assoc topic :stopped)))))
 
 (defn up-to-date? 
   "Returns true if all partitions of all topics subscribed to have had messages
@@ -141,6 +144,11 @@
         false
         true))))
 
+(defn consumers-closed?  []
+  (if (some #(= :running %) (vals @topic-state))
+    false
+    true))
+
 (defn subscribe!
   "Start a Kafka consumer listening to topics in topic-list
   Messages are transformed to RDF, if needed, and imported into triplestore"
@@ -150,7 +158,8 @@
     (let [thread (-> topic assign-topic! Thread.)]
       (log/info :fn :subscribe!
                 :msg (str "assigning " topic))
-      (.start thread))))
+      (.start thread)
+      (swap! topic-state assoc topic :running))))
 
 (defstate consumer-thread
   :start (let [topics (map keyword (s/split env/dx-topics #";"))]
@@ -209,3 +218,13 @@
 
 
 
+(defn update-db-from-stream
+  "Read the stream into the database to current offets. Returns when all topics have completed."
+  []
+  ;; open streams
+  (start topic-partitions)
+  ;; sync on all streams read to current offset
+  ;; close consumers
+  ;; sync on all consumers complete
+  ;; return
+  )

--- a/src/genegraph/sink/stream.clj
+++ b/src/genegraph/sink/stream.clj
@@ -22,7 +22,8 @@
 
 (def config (->> "kafka.edn" io/resource slurp edn/read-string (postwalk #(if (symbol? %) (-> % resolve var-get) %))))
 
-(def offset-file (str env/data-vol "/partition_offsets.edn"))
+(defn offset-file []
+  (str env/data-vol "/partition_offsets.edn"))
 
 (def current-offsets (atom {}))
 
@@ -102,13 +103,13 @@
 (defn update-offsets! [consumer tps]
   (doseq [tp tps]
     (swap! current-offsets assoc [(.topic tp) (.partition tp)] (.position consumer tp)))
-  (spit offset-file (pr-str @current-offsets)))
+  (spit (offset-file) (pr-str @current-offsets)))
 
 (def run-consumer (atom true))
 
 (defn read-offsets! [] 
-  (if (.exists (io/as-file offset-file))
-    (reset! current-offsets (-> offset-file slurp edn/read-string))
+  (if (.exists (io/as-file (offset-file)))
+    (reset! current-offsets (-> (offset-file) slurp edn/read-string))
     (reset! current-offsets {})))
 
 

--- a/src/genegraph/source/graphql/server_status.clj
+++ b/src/genegraph/source/graphql/server_status.clj
@@ -1,8 +1,7 @@
-(ns genegraph.source.graphql.server-status
-  (:require [genegraph.migration :as migration]))
+(ns genegraph.source.graphql.server-status)
 
 (defn server-version-query [context args value]
   true)
 
 (defn migration-version [context args value]
-  (migration/current-version))
+  "not defined")

--- a/src/genegraph/transform/core.clj
+++ b/src/genegraph/transform/core.clj
@@ -3,14 +3,15 @@
             [clojure.java.io :as io]
             [genegraph.env :as env]))
 
-(def target-base (str env/data-vol "/base/"))
+(defn target-base []
+  (str env/data-vol "/base/"))
 
-(defn src-path [doc-def] (str target-base (:target doc-def)))
+(defn src-path [doc-def] (str (target-base) (:target doc-def)))
 
 (defmulti transform-doc :format)
 
 (defmethod transform-doc :rdf [doc-def] 
   (with-open [is (if (:target doc-def)
-                   (io/input-stream (str target-base (:target doc-def)))
+                   (io/input-stream (str (target-base) (:target doc-def)))
                    (-> doc-def :document .getBytes java.io.ByteArrayInputStream.))] 
     (l/read-rdf is (:reader-opts doc-def))))


### PR DESCRIPTION
This wound up being a larger patch than I was hoping.

This represents a major change to the way Genegraph is deployed in production, with significant impacts to how it's used in development.

In production, Genegraph will now download a gzipped database, with indexes, from a google cloud bucket. This database needs to be uploaded, usually from a dev system. When genegraph is run, a base database version is specified via an environment variable (GENEGRAPH_DATA_VERSION). If the base database does not exist already in the target file system, Genegraph will download it (this is true in dev as well as stage). 

In order to implement this, some legacy functionality was removed. The state of base data downloads is no longer tracked. On rebuild, all base data will be downloaded fresh.