### PR TITLE
Allowing ws subscriptions, mostly necessary for Apollo (or similar)

### DIFF
--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -79,12 +79,12 @@
   (let [gql-schema (gql/schema)
         interceptors (-> (lacinia/default-interceptors gql-schema {})
                          (lacinia/inject open-tx-interceptor :before ::lacinia/query-executor)
-                         (lacinia/inject close-tx-interceptor :after ::lacinia/query-executor)
-)]
+                         (lacinia/inject close-tx-interceptor :after ::lacinia/query-executor))]
     (merge-with into  
                 (lacinia/service-map gql-schema
                                      {:graphiql true
-                                      :interceptors interceptors})
+                                      :interceptors interceptors
+                                      :subscriptions true})
                 model-pages
                 {::http/host "0.0.0.0"})))
 


### PR DESCRIPTION
Tiny change, just adding ws-subscriptions. This is mostly needed for certain classes of JS clients