### PR TITLE
Adding response cache, hashing keys in rocksdb

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,8 @@
                  [com.fasterxml.jackson.core/jackson-databind "2.11.0"]
                  [com.google.cloud/google-cloud-storage "1.108.0"]
                  [org.rocksdb/rocksdbjni "6.11.4"]
-                 [com.taoensso/nippy "2.15.0"]]
+                 [com.taoensso/nippy "2.15.0"]
+                 [digest "1.4.9"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources", "jars/REBL-0.9.220.jar"]
   ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency

--- a/src/genegraph/env.clj
+++ b/src/genegraph/env.clj
@@ -14,6 +14,7 @@
 (def use-gql-cache (System/getenv "GENEGRAPH_GQL_CACHE"))
 (def mode (System/getenv "GENEGRAPH_MODE"))
 (def validate-events (System/getenv "GENEGRAPH_VALIDATE_EVENTS"))
+(def use-response-cache (System/getenv "GENEGRAPH_RESPONSE_CACHE"))
 
 (defn log-environment []
   (log/info :fn :log-environment

--- a/src/genegraph/response_cache.clj
+++ b/src/genegraph/response_cache.clj
@@ -1,0 +1,34 @@
+(ns genegraph.response-cache
+  (:require [genegraph.rocksdb :as rocksdb]
+            [mount.core :refer [defstate]]
+            [io.pedestal.interceptor.chain :refer [terminate]]
+            [io.pedestal.log :as log]))
+
+(defstate cache-store
+  :start (rocksdb/open "response_cache")
+  :stop (rocksdb/close cache-store))
+
+(defn check-for-cached-response [context]
+  ;; (println (keys context))
+  (let [body (get-in context [:request :body])]
+    (if-let [cached-response (rocksdb/rocks-get cache-store body)]
+      (do
+        (log/debug :fn ::check-for-cached-response :msg "request cache hit")
+        (-> context
+            (assoc :response cached-response)
+            terminate))
+      (do 
+        (log/debug :fn ::check-for-cached-response :msg "request cache miss!")
+        context))))
+
+(defn store-processed-response [context]
+  (log/debug :fn ::store-processed-response :msg "storing processed response")
+  (rocksdb/rocks-put! cache-store 
+                      (get-in context [:request :body])
+                      (:response context))
+  context)
+
+(defn response-cache-interceptor []
+  {:name ::response-cache
+   :enter check-for-cached-response
+   :leave store-processed-response})

--- a/src/genegraph/rocksdb.clj
+++ b/src/genegraph/rocksdb.clj
@@ -1,6 +1,7 @@
 (ns genegraph.rocksdb
   (:require [genegraph.env :as env]
-            [taoensso.nippy :as nippy :refer [freeze thaw]])
+            [taoensso.nippy :as nippy :refer [freeze thaw]]
+            [digest])
   (:import (org.rocksdb RocksDB Options)))
 
 
@@ -11,14 +12,17 @@
     ;; todo add logging...
     (RocksDB/open opts full-path)))
 
+(defn key-digest [k]
+  (-> k freeze digest/md5 .getBytes))
+
 (defn rocks-put! [db k v]
-  (.put db (freeze k) (freeze v)))
+  (.put db (key-digest k) (freeze v)))
 
 (defn rocks-delete! [db k]
-  (.delete db (freeze k)))
+  (.delete db (key-digest k)))
 
 (defn rocks-get [db k]
-  (when-let [result (.get db (freeze k))]
+  (when-let [result (.get db (key-digest k))]
     (thaw result)))
 
 (defn close [db]


### PR DESCRIPTION
Two changes with this PR

* Added an (optionally configurable) cache to responses. Caches the entire response based on the request. Very fast, but kind of fragile, in that any change to the data requires expiring all the caches (not yet implemented)
* Perform MD5 on hash keys; this makes the bloom filter in RocksDB much more effective in preventing read IO, especially for cache misses. Will need to modify this behavior to support key prefixes, but should remove a performance bottleneck in the meantime.