### PR TITLE
Fixing cache code to respond appropriately to misses

### DIFF
--- a/src/genegraph/response_cache.clj
+++ b/src/genegraph/response_cache.clj
@@ -11,15 +11,16 @@
 (defn check-for-cached-response [context]
   ;; (println (keys context))
   (let [body (get-in context [:request :body])]
-    (if-let [cached-response (rocksdb/rocks-get cache-store body)]
-      (do
-        (log/debug :fn ::check-for-cached-response :msg "request cache hit")
-        (-> context
-            (assoc :response cached-response)
-            terminate))
-      (do 
-        (log/debug :fn ::check-for-cached-response :msg "request cache miss!")
-        context))))
+    (let [cached-response (rocksdb/rocks-get cache-store body)]
+      (if (= ::rocksdb/miss cached-response)
+        (do 
+          (log/debug :fn ::check-for-cached-response :msg "request cache miss!")
+          context)
+        (do
+          (log/debug :fn ::check-for-cached-response :msg "request cache hit")
+          (-> context
+              (assoc :response cached-response)
+              terminate))))))
 
 (defn store-processed-response [context]
   (log/debug :fn ::store-processed-response :msg "storing processed response")

--- a/src/genegraph/rocksdb.clj
+++ b/src/genegraph/rocksdb.clj
@@ -22,8 +22,9 @@
   (.delete db (key-digest k)))
 
 (defn rocks-get [db k]
-  (when-let [result (.get db (key-digest k))]
-    (thaw result)))
+  (if-let [result (.get db (key-digest k))]
+    (thaw result)
+    ::miss))
 
 (defn close [db]
   (.close db))

--- a/src/genegraph/source/graphql/common/cache.clj
+++ b/src/genegraph/source/graphql/common/cache.clj
@@ -28,13 +28,14 @@
          (do (log/debug :fn :defresolver :msg (str "in resolver " ~resolver-name))
              (let [cache-key# (conj ~args ~(str *ns* "." resolver-name))]
                (log/debug :fn :defresolver :msg (str "using cache, looking up " cache-key#))
-               (if-let [result# (get-from-cache cache-key#)]
-                 (do (log/debug :fn :defresolver :msg (str "cache hit: " result#))
-                     result#)
-                 (let [calculated-result# (do ~@body)]
-                   (log/debug :fn :defresolver :msg "cache miss")
-                   (store-in-cache! cache-key# calculated-result#)
-                   calculated-result#))))
+               (let [result# (get-from-cache cache-key#)]
+                 (if (= ::rocksdb/miss result#)
+                   (let [calculated-result# (do ~@body)]
+                     (log/debug :fn :defresolver :msg "cache miss")
+                     (store-in-cache! cache-key# calculated-result#)
+                     calculated-result#)
+                   (do (log/debug :fn :defresolver :msg (str "cache hit: " result#))
+                       result#)))))
          (do ~@body)))))
 
 ;; (defmacro defresolver


### PR DESCRIPTION
The cache code was initially written to report cache misses as nil. This meant that when nil was stored in the cache it would be treated by the handling code as a cache miss, forcing a lookup. This made some results on some expensive queries uncacheable. This was a foolish mistake, but this patch fixes it, cache misses now return ::miss; it's a requirement on calling code to handle this and respond appropriately.