### PR TITLE
Import legacy gci from neo4j

### DIFF
--- a/resources/batch-events.edn
+++ b/resources/batch-events.edn
@@ -1,0 +1,2 @@
+[{:name "gci-neo4j-archive"
+  :source "gci-neo4j-archive.tar.gz"}]

--- a/resources/formats.edn
+++ b/resources/formats.edn
@@ -9,4 +9,6 @@
  :gene-validity-raw {:genegraph.transform.core/format :gene-validity-v1}
  :gene-validity-raw-dev {:genegraph.transform.core/format :gene-validity-v1}
  :gci-legacy  {:genegraph.transform.core/format :gci-legacy
-               :genegraph.annotate/root-type :sepio/GeneValidityReport}}
+               :genegraph.annotate/root-type :sepio/GeneValidityReport}
+ :gene-validity-neo4j-export {:genegraph.transform.core/format :gene-validity-neo4j-export
+                              :genegraph.annotate/root-type :sepio/GeneValidityReport}}

--- a/src/genegraph/annotate.clj
+++ b/src/genegraph/annotate.clj
@@ -6,6 +6,7 @@
             [genegraph.transform.core :as transform]
             [genegraph.transform.gci-legacy :as gci-legacy]
             [genegraph.transform.actionability :as aci]
+            [genegraph.transform.gci-neo4j :as gci-neo4j]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
             [io.pedestal.log :as log]))

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -7,6 +7,7 @@
             [genegraph.database.instance :as db]
             [genegraph.sink.stream :as stream]
             [genegraph.suggest.suggesters :as suggest]
+            [genegraph.sink.batch :as batch]
             [mount.core :refer [start stop]]
             [clojure.java.shell :refer [sh]])
   (:import [java.time ZonedDateTime ZoneOffset]
@@ -37,6 +38,7 @@
     (fs/mkdirs env/data-vol)
     (start #'db/db)
     (base/initialize-db!)
+    (batch/proccess-batched-events!)
     (start #'stream/consumer-thread)
     ;; Address race where all threads are "up to date", needs better fix
     (Thread/sleep (* 1000 60 2))

--- a/src/genegraph/sink/batch.clj
+++ b/src/genegraph/sink/batch.clj
@@ -1,0 +1,1 @@
+(ns genegraph.sink.batch)

--- a/src/genegraph/sink/batch.clj
+++ b/src/genegraph/sink/batch.clj
@@ -1,1 +1,38 @@
-(ns genegraph.sink.batch)
+(ns genegraph.sink.batch
+  (:require [genegraph.sink.event :as event]
+            [genegraph.util.gcs :as gcs]
+            [genegraph.env :as env]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [me.raynes.fs :as fs]
+            [clojure.java.shell :refer [sh]])
+  (:import (java.io PushbackReader File)))
+
+(def batch-events "batch-events.edn")
+
+(defn process-directory! 
+  "Read and integrate a directory full of event records"
+  [path]
+  (let  [dir (File. path)
+         files (filter #(re-find #".*\.edn$" (.getName %)) (file-seq dir))]
+    (doseq [f files]
+      (with-open [rdr (io/reader f)
+                  pushback-rdr (PushbackReader. rdr)]
+        (println "processing: " f)
+        (event/process-event! (edn/read pushback-rdr))))))
+
+(defn proccess-batched-events! 
+  "Should be run during database initialization. Download and read events stored in batch format into database."
+  []
+  (let [target-dir (str env/data-vol "/events/")
+        batches (-> batch-events io/resource slurp edn/read-string)]
+    (doseq [batch batches]
+      (let [batch-dir (str target-dir (:name batch)) 
+            archive-path (str batch-dir ".tar.gz")]
+        (println (:name batch))
+        (fs/mkdirs batch-dir)
+        (gcs/get-file-from-bucket! (:source batch) archive-path)
+        (sh "tar" "-xzf" archive-path "-C" batch-dir)
+        (process-directory! batch-dir)))))
+
+

--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -4,10 +4,7 @@
             [genegraph.source.graphql.common.cache :as cache]
             [genegraph.annotate :as annotate :refer [add-model add-iri add-metadata add-validation]]
             [genegraph.database.validation :as v]
-            [io.pedestal.log :as log]
-            [clojure.edn :as edn]
-            [clojure.java.io :as io])
-  (:import (java.io PushbackReader File))
+            [io.pedestal.log :as log]))
 
 (defn add-to-db!
   "Adds model data to the db. As validation is configurable, this is done 
@@ -37,13 +34,3 @@
                             add-to-db!)]
     (cache/reset-cache!)
     processed-event))
-
-(defn process-directory! 
-  "Read and integrate a directory full of event records"
-  [path]
-  (let  [dir (File. path)
-         files (filter #(re-find #".*\.edn$" (.getName %)) (file-seq dir))]
-    (doseq [f files]
-      (with-open [rdr (io/reader f)
-                  pushback-rdr (PushbackReader. rdr)]
-        (process-event! (edn/read pushback-rdr))))))

--- a/src/genegraph/transform/gci_neo4j.clj
+++ b/src/genegraph/transform/gci_neo4j.clj
@@ -1,0 +1,87 @@
+(ns genegraph.transform.gci-neo4j
+  (:require [genegraph.transform.core :as xform :refer [add-model]]
+            [genegraph.database.load :as l]
+            [genegraph.database.query :as q]
+            [clojure.string :as s]))
+
+(def gci-root "http://dataexchange.clinicalgenome.org/gci/")
+(def affiliation-root "http://dataexchange.clinicalgenome.org/agent/")
+
+(defn validity-proposition [report iri]
+  [[iri :rdf/type :sepio/GeneValidityProposition]
+   [iri :sepio/has-subject (q/resource (:gene report))]
+   [iri :sepio/has-predicate :ro/IsCausalGermlineMutationIn]
+   [iri :sepio/has-object (q/resource (:disease report))]
+   [iri :sepio/has-qualifier (q/resource (:moi report))]])
+
+(def evidence-level-label-to-concept
+  {"Definitive" :sepio/DefinitiveEvidence
+   "Limited" :sepio/LimitedEvidence
+   "Moderate" :sepio/ModerateEvidence
+   "No Reported Evidence" :sepio/NoEvidence
+   "No Known Disease Relationship" :sepio/NoEvidence
+   "Strong*" :sepio/StrongEvidence
+   "Contradictory (disputed)" :sepio/DisputingEvidence
+   "Strong" :sepio/StrongEvidence
+   "Contradictory (refuted)" :sepio/RefutingEvidence
+   "Refuted" :sepio/RefutingEvidence
+   "Disputed" :sepio/DisputingEvidence
+   "No Classification" :sepio/NoEvidence})
+
+(def old-score-to-new
+  {"http://datamodel.clinicalgenome.org/terms/CG_000084" :sepio/DisputingEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000064" :sepio/StrongEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000066" :sepio/LimitedEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000067" :sepio/NoEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000063" :sepio/DefinitiveEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000085" :sepio/RefutingEvidence
+   "http://datamodel.clinicalgenome.org/terms/CG_000065" :sepio/ModerateEvidence})
+
+(def gci-sop-version 
+  {"5" :sepio/ClinGenGeneValidityEvaluationCriteriaSOP5
+   "6" :sepio/ClinGenGeneValidityEvaluationCriteriaSOP6
+   "7" :sepio/ClinGenGeneValidityEvaluationCriteriaSOP7})
+
+(defn contribution [report iri]
+  [[iri :bfo/realizes :sepio/ApproverRole]
+   [iri :sepio/has-agent  (q/resource 
+                           (s/replace (:gcep report)
+                                      "https://search.clinicalgenome.org/kb/agents/"
+                                      affiliation-root))]
+   [iri :sepio/activity-date (:date report)]])
+
+(defn evidence-level-assertion [report iri id]
+  (let [prop-iri (q/resource (str gci-root "proposition_" id))
+        contribution-iri (l/blank-node)]
+    (concat [[iri :rdf/type :sepio/GeneValidityEvidenceLevelAssertion]
+             [iri :sepio/has-subject prop-iri]
+             [iri :sepio/has-predicate :sepio/HasEvidenceLevel]
+             [iri :sepio/has-object (old-score-to-new (:score report))]
+             [iri :sepio/qualified-contribution contribution-iri]
+             [iri :sepio/is-specified-by (gci-sop-version (:sop-version report))]]
+            (validity-proposition report prop-iri)
+             (contribution report contribution-iri))))
+
+(defn json-content-node [report iri]
+  [[iri :rdf/type :cnt/ContentAsText]
+   [iri :cnt/chars (:score-string report)]])
+
+(defn gci-neo4j-export-to-triples [report]
+  (let [root-version (str gci-root (:id report))
+        id (str (:id report) "-" (s/replace (:date report) #":" ""))
+        iri (q/resource (str gci-root "report_" id))
+        content-id (l/blank-node)
+        assertion-id (q/resource (str gci-root "assertion_" id))]
+    (concat [[iri :rdf/type :sepio/GeneValidityReport] 
+             [iri :rdfs/label (:title report)]
+             [iri :bfo/has-part content-id]
+             [iri :bfo/has-part assertion-id]]
+            (evidence-level-assertion report assertion-id id)
+            (json-content-node report content-id)))) 
+
+(defmethod add-model :gene-validity-neo4j-export [event]
+  (let [report (:genegraph.sink.event/value event)
+        triples (gci-neo4j-export-to-triples report)]
+    (assoc event
+           ::q/model
+           (l/statements-to-model triples))))

--- a/src/genegraph/util/gcs.clj
+++ b/src/genegraph/util/gcs.clj
@@ -17,7 +17,7 @@
 
 (defn put-file-in-bucket!
   ([source-file blob-name]
-   (put-in-bucket! source-file blob-name {:content-type "application/gzip"}))
+   (put-file-in-bucket! source-file blob-name {:content-type "application/gzip"}))
   ([source-file blob-name options]
    (let [gc-storage (.getService (StorageOptions/getDefaultInstance))
          blob-id (BlobId/of env/genegraph-bucket blob-name)

--- a/src/genegraph/util/gcs.clj
+++ b/src/genegraph/util/gcs.clj
@@ -1,0 +1,36 @@
+(ns genegraph.util.gcs
+  (:require [genegraph.env :as env]
+            [me.raynes.fs :as fs])
+  (:import [java.time ZonedDateTime ZoneOffset]
+           java.time.format.DateTimeFormatter
+           [java.nio ByteBuffer]
+           [java.nio.file Path Paths]
+           [java.io InputStream OutputStream FileInputStream File]
+           [com.google.common.io ByteStreams]
+           [org.apache.kafka.clients.producer Producer KafkaProducer ProducerRecord]
+           [com.google.cloud.storage Bucket BucketInfo Storage StorageOptions
+            BlobId BlobInfo Blob]
+           [com.google.cloud.storage Storage$BlobWriteOption
+            Storage$BlobTargetOption
+            Storage$BlobSourceOption
+            Blob$BlobSourceOption]))
+
+(defn put-file-in-bucket!
+  ([source-file blob-name]
+   (put-in-bucket! source-file blob-name {:content-type "application/gzip"}))
+  ([source-file blob-name options]
+   (let [gc-storage (.getService (StorageOptions/getDefaultInstance))
+         blob-id (BlobId/of env/genegraph-bucket blob-name)
+         blob-info (-> blob-id BlobInfo/newBuilder (.setContentType (:content-type options)) .build)
+         from (.getChannel (FileInputStream. source-file))]
+     (with-open [to (.writer gc-storage blob-info (make-array Storage$BlobWriteOption 0))]
+       (ByteStreams/copy from to)))))
+
+(defn get-file-from-bucket!
+  [source-blob target-file]
+  (let [target-path (Paths/get target-file
+                               (make-array java.lang.String 0))
+        blob (.get (.getService (StorageOptions/getDefaultInstance))
+                   (BlobId/of env/genegraph-bucket source-blob))]
+    (println source-blob " " target-file)
+    (.downloadTo blob target-path)))


### PR DESCRIPTION
This PR adds a couple of features
* Import format for the export from Neo4j of Gene validity messages
* Importer for zipped batches of events to handle above.