### PR TITLE
Query refactor

### DIFF
--- a/src/genegraph/database/load.clj
+++ b/src/genegraph/database/load.clj
@@ -47,7 +47,7 @@
          subject (cond
                    (keyword? s) (local-class-names s)
                    (string? s) (ResourceFactory/createResource s)
-                   (satisfies? q/AsJenaResource s) (q/as-jena-resource s)
+                   (q/resource? s) (q/as-jena-resource s)
                    :else s)
          predicate (if (keyword? p)
                      (local-property-names p)
@@ -58,7 +58,7 @@
                   (or (string? o)
                       (int? o)
                       (float? o)) (ResourceFactory/createTypedLiteral o)
-                  (satisfies? q/AsJenaResource o) (q/as-jena-resource o)
+                  (q/resource? o) (q/as-jena-resource o)
                   :else o)]
      (ResourceFactory/createStatement subject predicate object))))
 

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -58,17 +58,17 @@
   "Create a resource reference defined by either a keyword (known to the system),
   or a string containing the IRI of an RDF Resource"
   [r]
-  (resource/resource r))
+  (types/resource r))
 
 (defn ld->
   "Return the non-nil targets of resouce following key sequence of properties"
   [resource ks]
-  (resource/ld-> resource ks))
+  (types/ld-> resource ks))
 
 (defn ld1->
   "Return the first non-nil target of resouce following key sequence of properties"
   [resource ks]
-  (resource/ld1-> resource ks))
+  (types/ld1-> resource ks))
 
 (defn construct 
   "Return a model built using a SPARQL CONSTRUCT query, accepts a SPARQL string,

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -1,5 +1,6 @@
 (ns genegraph.database.query
-  (:require [clojure.java.io :as io]
+  (:require [genegraph.database.query.types :as types]
+            [clojure.java.io :as io]
             [clojure.string :as s]
             [genegraph.database.instance :refer [db]]
             [genegraph.database.names :as names]
@@ -22,7 +23,7 @@
 (defn resource?
   "Return true if the object is an RDFResource"
   [r]
-  (satisfies? resource/AsJenaResource r))
+  (types/resource? r))
 
 (defn as-jena-resource
   "Return the underlying Jena Resource under the RDFResource"

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -28,24 +28,24 @@
 (defn as-jena-resource
   "Return the underlying Jena Resource under the RDFResource"
   [r]
-  (resource/as-jena-resource r))
+  (types/as-jena-resource r))
 
 (defn is-rdf-type?
   "Return true if r is an instance of rdf-type"
   [r rdf-type]
-  (resource/is-rdf-type? r rdf-type))
+  (types/is-rdf-type? r rdf-type))
 
 (defn to-ref
   "Return the keyword associated with this resource (if any)"
   [r]
-  (resource/to-ref r))
+  (types/to-ref r))
 
 (defn path 
   "Return the URL by which this resource can be addressed in the system
 
   DEPRECATED this responsibility should lie elsewhere"
   [r]
-  (resource/path r))
+  (types/path r))
 
 (defn select
   "Execute a SPARQL SELECT query (in string form). Will return a vector of results. Typical use is

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -1,31 +1,15 @@
 (ns genegraph.database.query
-  (:require [genegraph.database.query.resource :as resource]
-            [genegraph.database.instance :refer [db]]
-            [genegraph.database.util :as util :refer [tx]]
-            [genegraph.database.names :as names :refer
-             [local-class-names local-property-names
-              class-uri->keyword local-names ns-prefix-map
-              prefix-ns-map property-uri->keyword]]
-            [clojure.pprint :refer [pprint]]
-            [clojure.set :as set]
+  (:require [clojure.java.io :as io]
             [clojure.string :as s]
-            [clojure.core.protocols :as protocols :refer [Datafiable]]
-            [clojure.datafy :as datafy :refer [datafy nav]]
-            [io.pedestal.log :as log]
-            [medley.core :as medley]
-            [clojure.java.io :as io]
-            [taoensso.nippy :as nippy])
-  (:import [org.apache.jena.rdf.model Model Statement ResourceFactory Resource Literal RDFList SimpleSelector ModelFactory]
-           [org.apache.jena.query Dataset QueryFactory Query QueryExecution
-            QueryExecutionFactory QuerySolutionMap]
-           [org.apache.jena.sparql.algebra AlgebraGenerator Algebra OpAsQuery Op]
-           [org.apache.jena.graph Node NodeFactory Triple Node_Variable Node_Blank]
-[org.apache.jena.sparql.algebra.op OpDistinct OpProject OpFilter OpBGP OpConditional OpDatasetNames OpDiff OpDisjunction OpDistinctReduced OpExtend OpGraph OpGroup OpJoin OpLabel OpLeftJoin OpList OpMinus OpNull OpOrder OpQuad OpQuadBlock OpQuadPattern OpReduced OpSequence OpSlice OpTopN OpUnion OpTable ]
-[org.apache.jena.sparql.core BasicPattern Var VarExprList QuadPattern Quad]
-           org.apache.jena.riot.writer.JsonLDWriter
-           org.apache.jena.sparql.core.Prologue
-           org.apache.jena.riot.RDFFormat$JSONLDVariant
-           java.io.ByteArrayOutputStream))
+            [genegraph.database.instance :refer [db]]
+            [genegraph.database.names :as names]
+            [genegraph.database.query.resource :as resource]
+            [genegraph.database.util :as util])
+  (:import java.io.ByteArrayOutputStream
+           org.apache.jena.graph.NodeFactory
+           org.apache.jena.query.QueryFactory
+           org.apache.jena.rdf.model.ModelFactory
+           org.apache.jena.sparql.algebra.Algebra))
 
 (defn get-all-graphs []
   (or @util/current-union-model (.getUnionModel db)))

--- a/src/genegraph/database/query/algebra.clj
+++ b/src/genegraph/database/query/algebra.clj
@@ -1,0 +1,28 @@
+(ns genegraph.database.query.algebra
+    (:require [genegraph.database.instance :refer [db]]
+            [genegraph.database.util :as util :refer [tx]]
+            [genegraph.database.names :as names :refer
+             [local-class-names local-property-names
+              class-uri->keyword local-names ns-prefix-map
+              prefix-ns-map property-uri->keyword]]
+            [clojure.pprint :refer [pprint]]
+            [clojure.set :as set]
+            [clojure.string :as s]
+            [clojure.core.protocols :as protocols :refer [Datafiable]]
+            [clojure.datafy :as datafy :refer [datafy nav]]
+            [io.pedestal.log :as log]
+            [medley.core :as medley]
+            [clojure.java.io :as io]
+            [taoensso.nippy :as nippy])
+    (:import [org.apache.jena.rdf.model Model Statement ResourceFactory Resource Literal RDFList SimpleSelector ModelFactory]
+             [org.apache.jena.query Dataset QueryFactory Query QueryExecution
+              QueryExecutionFactory QuerySolutionMap]
+             [org.apache.jena.sparql.algebra AlgebraGenerator Algebra OpAsQuery Op]
+             [org.apache.jena.graph Node NodeFactory Triple Node_Variable Node_Blank]
+             [org.apache.jena.sparql.algebra.op OpDistinct OpProject OpFilter OpBGP OpConditional OpDatasetNames OpDiff OpDisjunction OpDistinctReduced OpExtend OpGraph OpGroup OpJoin OpLabel OpLeftJoin OpList OpMinus OpNull OpOrder OpQuad OpQuadBlock OpQuadPattern OpReduced OpSequence OpSlice OpTopN OpUnion OpTable ]
+             [org.apache.jena.sparql.core BasicPattern Var VarExprList QuadPattern Quad]
+             org.apache.jena.riot.writer.JsonLDWriter
+             org.apache.jena.sparql.core.Prologue
+             org.apache.jena.riot.RDFFormat$JSONLDVariant
+             java.io.ByteArrayOutputStream))
+

--- a/src/genegraph/database/query/algebra.clj
+++ b/src/genegraph/database/query/algebra.clj
@@ -1,5 +1,6 @@
 (ns genegraph.database.query.algebra
     (:require [genegraph.database.instance :refer [db]]
+              [genegraph.database.query.types :as types]
             [genegraph.database.util :as util :refer [tx]]
             [genegraph.database.names :as names :refer
              [local-class-names local-property-names
@@ -26,3 +27,71 @@
              org.apache.jena.riot.RDFFormat$JSONLDVariant
              java.io.ByteArrayOutputStream))
 
+(defn- var-seq [vars]
+  (map #(Var/alloc (str %)) vars))
+
+(defn triple
+  "Construct triple for use in BGP. Part of query algebra."
+  [stmt]
+  (let [[s p o] stmt
+        subject (cond
+                  (instance? Node s) s
+                  (= '_ s) Var/ANON
+                  (symbol? s) (Var/alloc (str s))
+                  (keyword? s) (.asNode (local-class-names s))
+                  (string? s) (NodeFactory/createURI s)
+                  (types/resource? o) (.asNode (types/as-jena-resource s))
+                  :else (NodeFactory/createURI (str s)))
+        predicate (cond
+                    (instance? Node p) p
+                    (keyword? p) (.asNode (local-property-names p))
+                    :else (NodeFactory/createURI (str p)))
+        object (cond 
+                 (instance? Node o) o
+                 (symbol? o) (Var/alloc (str o))
+                 (keyword? o) (.asNode (or (local-class-names o) (local-property-names o)))
+                 (or (string? o)
+                     (int? o)
+                     (float? o)) (.asNode (ResourceFactory/createTypedLiteral o))
+                 (types/resource? o) (.asNode (types/as-jena-resource o))
+                 :else o)]
+    (Triple. subject predicate object)))
+
+(declare op)
+
+(defn- op-union [a1 a2 & amore]
+  (OpUnion. 
+   (op a1)
+   (if amore
+     (apply op-union a2 amore)
+     (op a2))))
+
+(defn op
+  "Convert a Clojure data structure to an Arq Op"
+  [[op-name & [a1 a2 & amore :as args]]]
+  (case op-name
+    :distinct (OpDistinct/create (op a1))
+    :project (OpProject. (op a2) (var-seq a1))
+    ;; :filter (OpFilter/filterBy (ExprList. ^List (map expr (butlast args))) (op (last args)))
+    :bgp (OpBGP. (BasicPattern/wrap (map triple args)))
+    :conditional (OpConditional. (op a1) (op a2))
+    :diff (OpDiff/create (op a1) (op a2))
+    :disjunction (OpDisjunction/create (op a1) (op a2))
+    ;; :extend (OpExtend/create (op a2) (var-expr-list a1))
+    ;; :group (OpGroup/create (op (first amore))
+    ;;                        (VarExprList. ^List (var-seq a1))
+    ;;                        (var-aggr-list a2))
+    :join (OpJoin/create (op a1) (op a2))
+    :label (OpLabel/create a1 (op a2))
+    ;; :left-join (OpLeftJoin/create (op a1) (op a2) (ExprList. ^List (map expr amore)))
+    :list (OpList. (op a1))
+    :minus (OpMinus/create (op a1) (op a2))
+    :null (OpNull/create)
+    ;; :order (OpOrder. (op a2) (sort-conditions a1))
+    :reduced (OpReduced/create (op a1))
+    :sequence (OpSequence/create (op a1) (op a2))
+    :slice (OpSlice. (op a1) (long a1) (long (first amore)))
+    ;; :top-n (OpTopN. (op (first amore)) (long a1) (sort-conditions a2))
+    :union (apply op-union args)
+    (throw (ex-info (str "Unknown operation " op-name) {:op-name op-name
+                                                        :args args}))))

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -1,32 +1,16 @@
 (ns genegraph.database.query.resource
-  (:require [genegraph.database.instance :refer [db]]
-            [genegraph.database.util :as util :refer [tx]]
-            [genegraph.database.query.types :as types]
+  (:require [clojure.string :as s]
+            [genegraph.database.instance :refer [db]]
+            [genegraph.database.names :as names :refer [local-names prefix-ns-map]]
             [genegraph.database.query.algebra :as algebra]
-            [genegraph.database.names :as names :refer
-             [local-class-names local-property-names
-              class-uri->keyword local-names ns-prefix-map
-              prefix-ns-map property-uri->keyword]]
-            [clojure.pprint :refer [pprint]]
-            [clojure.set :as set]
-            [clojure.string :as s]
-            [clojure.core.protocols :as protocols :refer [Datafiable]]
-            [clojure.datafy :as datafy :refer [datafy nav]]
+            [genegraph.database.query.types :as types]
+            [genegraph.database.util :as util :refer [tx]]
             [io.pedestal.log :as log]
-            [medley.core :as medley]
-            [clojure.java.io :as io]
-            [taoensso.nippy :as nippy])
-  (:import [org.apache.jena.rdf.model Model Statement ResourceFactory Resource Literal RDFList SimpleSelector ModelFactory]
-           [org.apache.jena.query Dataset QueryFactory Query QueryExecution
-            QueryExecutionFactory QuerySolutionMap]
-           [org.apache.jena.sparql.algebra AlgebraGenerator Algebra OpAsQuery Op]
-           [org.apache.jena.graph Node NodeFactory Triple Node_Variable Node_Blank]
-[org.apache.jena.sparql.algebra.op OpDistinct OpProject OpFilter OpBGP OpConditional OpDatasetNames OpDiff OpDisjunction OpDistinctReduced OpExtend OpGraph OpGroup OpJoin OpLabel OpLeftJoin OpList OpMinus OpNull OpOrder OpQuad OpQuadBlock OpQuadPattern OpReduced OpSequence OpSlice OpTopN OpUnion OpTable ]
-[org.apache.jena.sparql.core BasicPattern Var VarExprList QuadPattern Quad]
-           org.apache.jena.riot.writer.JsonLDWriter
-           org.apache.jena.sparql.core.Prologue
-           org.apache.jena.riot.RDFFormat$JSONLDVariant
-           java.io.ByteArrayOutputStream))
+            [medley.core :as medley])
+  (:import java.io.ByteArrayOutputStream
+           [org.apache.jena.query Dataset Query QueryExecutionFactory QueryFactory QuerySolutionMap]
+           [org.apache.jena.rdf.model ModelFactory Resource ResourceFactory]
+           org.apache.jena.sparql.algebra.OpAsQuery))
 
 (defn to-ref [r]
   (types/to-ref r))

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -174,15 +174,7 @@
                                  (filter seq) flatten))
                           [this] 
                           ks))
-  (ld1-> [this ks] (first (ld-> this ks)))
-  
-  ;; TODO Root path is hardcoded in--this should be configurable
-  Addressable
-  (path [_] (let [uri (.getURI resource)
-                  short-ns (names/curie uri)
-                  full-ns (prefix-ns-map short-ns)
-                  id (subs uri (count full-ns))]
-              (str "/r/" short-ns "_" id))))
+  (ld1-> [this ks] (first (ld-> this ks))))
 
 (nippy/extend-freeze 
  RDFResource ::rdf-resource
@@ -194,6 +186,13 @@
  [data-input]
  (when-let [resource-iri (.readUTF data-input)]
    (resource resource-iri)))
+
+(defn path [r]
+  (let [uri (str resource)
+        short-ns (names/curie uri)
+        full-ns (prefix-ns-map short-ns)
+        id (subs uri (count full-ns))]
+    (str "/r/" short-ns "_" id)))
 
 (defn- navize [model]
   (fn [coll k v]

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -2,6 +2,7 @@
   (:require [genegraph.database.instance :refer [db]]
             [genegraph.database.util :as util :refer [tx]]
             [genegraph.database.query.types :as types]
+            [genegraph.database.query.algebra :as algebra]
             [genegraph.database.names :as names :refer
              [local-class-names local-property-names
               class-uri->keyword local-names ns-prefix-map
@@ -214,114 +215,6 @@
     (doseq [model models] (.add union-model model))
     union-model))
 
-
-;;;; Query builder
-
-(defn text-index [var ])
-
-(defn triple
-  "Construct triple for use in BGP. Part of query algebra."
-  [stmt]
-  (let [[s p o] stmt
-        subject (cond
-                  (instance? Node s) s
-                  (= '_ s) Var/ANON
-                  (symbol? s) (Var/alloc (str s))
-                  (keyword? s) (.asNode (local-class-names s))
-                  (string? s) (NodeFactory/createURI s)
-                  (types/resource? o) (.asNode (as-jena-resource s))
-                  :else (NodeFactory/createURI (str s)))
-        predicate (cond
-                    (instance? Node p) p
-                    (keyword? p) (.asNode (local-property-names p))
-                    :else (NodeFactory/createURI (str p)))
-        object (cond 
-                 (instance? Node o) o
-                 (symbol? o) (Var/alloc (str o))
-                 (keyword? o) (.asNode (or (local-class-names o) (local-property-names o)))
-                 (or (string? o)
-                     (int? o)
-                     (float? o)) (.asNode (ResourceFactory/createTypedLiteral o))
-                 (types/resource? o) (.asNode (as-jena-resource o))
-                 :else o)]
-    (Triple. subject predicate object)))
-
-;; (defn expr
-;;   "Convert a Clojure data structure to an Arq Expr"
-;;   [expr]
-;;   (if (instance? java.util.List expr)
-;;     (composite-expr expr)
-;;     (let [node (graph/node expr)]
-;;       (if (instance? Node_Variable node)
-;;         (ExprVar. (Var/alloc ^Node_Variable node))
-;;         (NodeValue/makeNode node)))))
-
-;; (defn- var-expr-list
-;;   "Given a vector of var/expr bindings (reminiscient of Clojure's `let`), return a Jena VarExprList with vars and exprs."
-;;   [bindings]
-;;   (let [vel (VarExprList.)]
-;;     (doseq [[v e] (partition 2 bindings)]
-;;       (.add vel (Var/alloc (graph/node v))
-;;         (expr e)))
-;;     vel))
-
-;; (defn- var-aggr-list
-;;   "Given a vector of var/aggregate bindings return a Jena VarExprList with
-;;    vars and aggregates"
-;;   [bindings]
-;;   (vec (for [[v e] (partition 2 bindings)]
-;;          (ExprAggregator. (Var/alloc (graph/node v)) (aggregator e)))))
-
-;; (defn- sort-conditions
-;;   "Given a seq of expressions and the keyword :asc or :desc, return a list of
-;;    sort conditions."
-;;   [conditions]
-;;   (for [[e dir] (partition 2 conditions)]
-;;     (SortCondition. ^Expr (expr e) (if (= :asc dir) 1 -1))))
-
-(defn- var-seq [vars]
-  (map #(Var/alloc (str %)) vars))
-
-(declare op)
-
-(defn- op-union [a1 a2 & amore]
-  (OpUnion. 
-   (op a1)
-   (if amore
-     (apply op-union a2 amore)
-     (op a2))))
-
-(defn op
-  "Convert a Clojure data structure to an Arq Op"
-  [[op-name & [a1 a2 & amore :as args]]]
-  (case op-name
-    :distinct (OpDistinct/create (op a1))
-    :project (OpProject. (op a2) (var-seq a1))
-    ;; :filter (OpFilter/filterBy (ExprList. ^List (map expr (butlast args))) (op (last args)))
-    :bgp (OpBGP. (BasicPattern/wrap (map triple args)))
-    :conditional (OpConditional. (op a1) (op a2))
-    :diff (OpDiff/create (op a1) (op a2))
-    :disjunction (OpDisjunction/create (op a1) (op a2))
-    ;; :extend (OpExtend/create (op a2) (var-expr-list a1))
-    ;; :group (OpGroup/create (op (first amore))
-    ;;                        (VarExprList. ^List (var-seq a1))
-    ;;                        (var-aggr-list a2))
-    :join (OpJoin/create (op a1) (op a2))
-    :label (OpLabel/create a1 (op a2))
-    ;; :left-join (OpLeftJoin/create (op a1) (op a2) (ExprList. ^List (map expr amore)))
-    :list (OpList. (op a1))
-    :minus (OpMinus/create (op a1) (op a2))
-    :null (OpNull/create)
-    ;; :order (OpOrder. (op a2) (sort-conditions a1))
-    :reduced (OpReduced/create (op a1))
-    :sequence (OpSequence/create (op a1) (op a2))
-    :slice (OpSlice. (op a1) (long a1) (long (first amore)))
-    ;; :top-n (OpTopN. (op (first amore)) (long a1) (sort-conditions a2))
-    :union (apply op-union args)
-    (throw (ex-info (str "Unknown operation " op-name) {:op-name op-name
-                                                        :args args}))))
-
-
 (defn- compose-select-result [qexec model]
   (when-let [result (-> qexec .execSelect)]
     (let [result-var (-> result .getResultVars first)
@@ -359,7 +252,7 @@ use io/slurp"
   ([query-source] (create-query query-source {}))
   ([query-source params]
    (let [query (if  (coll? query-source)
-                  (OpAsQuery/asQuery (op query-source))
+                  (OpAsQuery/asQuery (algebra/op query-source))
                   (QueryFactory/create (expand-query-str
                                         (if (string? query-source)
                                           query-source

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -12,36 +12,12 @@
            [org.apache.jena.rdf.model ModelFactory Resource ResourceFactory]
            org.apache.jena.sparql.algebra.OpAsQuery))
 
-(defn to-ref [r]
-  (types/to-ref r))
-
-(defn to-clj [r model]
-  (types/to-clj r model))
-
-(defn to-rdf-node [v]
-  (types/to-rdf-node v))
-
 (defprotocol SelectQuery
   (select [query-def] [query-def params] [query-def params model]))
 
 (defprotocol AsResource
   "Create an RDFResource given a reference"
   (resource [r] [ns-prefix r]))
-
-(defn path [r]
-  (types/path r))
-
-(defn ld-> [r ks]
-  (types/ld-> r ks))
-
-(defn ld1-> [r ks]
-  (types/ld1-> r ks))
-
-(defn is-rdf-type? [r rdf-type]
-  (types/is-rdf-type? r rdf-type))
-
-(defn as-jena-resource [r]
-  (types/as-jena-resource r))
 
 (defn get-all-graphs []
   (or @util/current-union-model (.getUnionModel db)))
@@ -110,7 +86,7 @@
 (defn- construct-query-solution-map [params]
   (let [qs-map (QuerySolutionMap.)]
     (doseq [[k v] params]
-      (.add qs-map (name k) (to-rdf-node v)))
+      (.add qs-map (name k) (types/to-rdf-node v)))
     qs-map))
 
 (extend-protocol SelectQuery

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -27,28 +27,11 @@
            org.apache.jena.riot.RDFFormat$JSONLDVariant
            java.io.ByteArrayOutputStream))
 
-;; (defprotocol Steppable
-;;   (step [edge start model]))
-
-
-
-
-
-
-;; (defprotocol AsReference
-;;   (to-ref [resource]))
-
 (defn to-ref [r]
   (types/to-ref r))
 
-;; (defprotocol AsClojureType
-;;   (to-clj [x model]))
-
 (defn to-clj [r model]
   (types/to-clj r model))
-
-;; (defprotocol AsRDFNode
-;;   (to-rdf-node [x]))
 
 (defn to-rdf-node [v]
   (types/to-rdf-node v))
@@ -63,26 +46,14 @@
 (defn path [r]
   (types/path r))
 
-;; (defprotocol ThreadableData
-;;   "A data structure that can be accessed through the ld-> and ld1-> accessors
-;;   similar to Clojure XML zippers"
-;;   (ld-> [this ks])
-;;   (ld1-> [this ks]))
-
 (defn ld-> [r ks]
   (types/ld-> r ks))
 
 (defn ld1-> [r ks]
   (types/ld1-> r ks))
 
-;; (defprotocol RDFType
-;;   (is-rdf-type? [this rdf-type]))
-
 (defn is-rdf-type? [r rdf-type]
   (types/is-rdf-type? r rdf-type))
-
-;; (defprotocol AsJenaResource
-;;   (as-jena-resource [this]))
 
 (defn as-jena-resource [r]
   (types/as-jena-resource r))

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -1,6 +1,7 @@
 (ns genegraph.database.query.resource
   (:require [genegraph.database.instance :refer [db]]
             [genegraph.database.util :as util :refer [tx]]
+            [genegraph.database.query.types :as types]
             [genegraph.database.names :as names :refer
              [local-class-names local-property-names
               class-uri->keyword local-names ns-prefix-map
@@ -26,17 +27,31 @@
            org.apache.jena.riot.RDFFormat$JSONLDVariant
            java.io.ByteArrayOutputStream))
 
-(defprotocol Steppable
-  (step [edge start model]))
+;; (defprotocol Steppable
+;;   (step [edge start model]))
 
-(defprotocol AsReference
-  (to-ref [resource]))
 
-(defprotocol AsClojureType
-  (to-clj [x model]))
 
-(defprotocol AsRDFNode
-  (to-rdf-node [x]))
+
+
+
+;; (defprotocol AsReference
+;;   (to-ref [resource]))
+
+(defn to-ref [r]
+  (types/to-ref r))
+
+;; (defprotocol AsClojureType
+;;   (to-clj [x model]))
+
+(defn to-clj [r model]
+  (types/to-clj r model))
+
+;; (defprotocol AsRDFNode
+;;   (to-rdf-node [x]))
+
+(defn to-rdf-node [v]
+  (types/to-rdf-node v))
 
 (defprotocol SelectQuery
   (select [query-def] [query-def params] [query-def params model]))
@@ -45,23 +60,32 @@
   "Create an RDFResource given a reference"
   (resource [r] [ns-prefix r]))
 
-(defprotocol Addressable
-  "Retrieves the local path to a resource"
-  (path [this]))
+(defn path [r]
+  (types/path r))
 
-(defprotocol ThreadableData
-  "A data structure that can be accessed through the ld-> and ld1-> accessors
-  similar to Clojure XML zippers"
-  (ld-> [this ks])
-  (ld1-> [this ks]))
+;; (defprotocol ThreadableData
+;;   "A data structure that can be accessed through the ld-> and ld1-> accessors
+;;   similar to Clojure XML zippers"
+;;   (ld-> [this ks])
+;;   (ld1-> [this ks]))
 
-(defprotocol RDFType
-  (is-rdf-type? [this rdf-type]))
+(defn ld-> [r ks]
+  (types/ld-> r ks))
 
-(defprotocol AsJenaResource
-  (as-jena-resource [this]))
+(defn ld1-> [r ks]
+  (types/ld1-> r ks))
 
-(declare datafy-resource)
+;; (defprotocol RDFType
+;;   (is-rdf-type? [this rdf-type]))
+
+(defn is-rdf-type? [r rdf-type]
+  (types/is-rdf-type? r rdf-type))
+
+;; (defprotocol AsJenaResource
+;;   (as-jena-resource [this]))
+
+(defn as-jena-resource [r]
+  (types/as-jena-resource r))
 
 (defn get-all-graphs []
   (or @util/current-union-model (.getUnionModel db)))
@@ -71,17 +95,7 @@
   [resource]
   (names/curie (str resource)))
 
-(defn- compose-object-for-datafy [o]
-  (cond (instance? Literal o) (.toString o)
-        (instance? Resource o) 
-        (with-meta (-> o .toString symbol)
-          {::datafy/obj o
-           ::datafy/class (class o)
-           `protocols/datafy #(-> % meta ::datafy/obj datafy-resource)})))
-
 (declare navize)
-
-(declare to-clj)
 
 (def query-sort-order 
   {:ASC Query/ORDER_ASCENDING
@@ -105,88 +119,6 @@
       modified-query)
     query))
 
-(deftype RDFResource [resource model]
-
-  AsJenaResource
-  (as-jena-resource [_] resource)
-
-  RDFType
-  (is-rdf-type? [this rdf-type] 
-    (let [t (if (= (type rdf-type) clojure.lang.Keyword) 
-              (local-names rdf-type)
-              (ResourceFactory/createResource rdf-type))]
-      (tx (.contains model resource (local-names :rdf/type) t))))
-
-  ;; TODO, returns all properties when k does not map to a known symbol,
-  ;; This seems to break the contract for ILookup
-  clojure.lang.ILookup
-  (valAt [this k] (step k this model))
-  (valAt [this k nf] nf)
-
-
-  ;; Conforms to the expectations for a sequence representation of a map. Includes only
-  ;; properties where this resource is the subject. Sequence is fully realized
-  ;; in order to permit access outside transaction
-  clojure.lang.Seqable
-  (seq [this]
-    (tx
-     (let [out-attributes (-> model (.listStatements resource nil nil) iterator-seq)]
-       (doall (map #(vector 
-                     (-> % .getPredicate property-uri->keyword)
-                     (to-clj (.getObject %) model)) out-attributes)))))
-
-  Object
-  (toString [_] (.getURI resource))
-  (equals [this other]
-    (and (satisfies? AsJenaResource other)
-         (= resource (as-jena-resource other))))
-  (hashCode [_] (.hashCode resource))
-  
-
-  AsReference
-  (to-ref [_] (class-uri->keyword resource))
-
-  Datafiable
-  (datafy [_] 
-    (tx 
-     (let [out-attributes (-> model (.listStatements resource nil nil) iterator-seq)
-           in-attributes (-> model (.listStatements nil nil resource) iterator-seq)]
-
-       (with-meta
-         (into [] (concat
-                   (mapv #(with-meta [[(-> % .getPredicate property-uri->keyword) :>]
-                                      (-> % .getObject compose-object-for-datafy)]
-                            {:genegraph.database.query/value  (.getObject %)})
-                         out-attributes)
-                   (mapv #(with-meta [[(-> % .getPredicate property-uri->keyword) :<]
-                                      (-> % .getSubject compose-object-for-datafy)]
-                            {:genegraph.database.query/value (.getSubject %)})
-                         in-attributes)))
-         {`protocols/nav (navize model)}))))
-
-  ;; TODO Flattening the ld-> has potentially undesirable behavior with RDFList, consider
-  ;; how flatten is being used in this context
-  ThreadableData
-  (ld-> [this ks] (reduce (fn [nodes k]
-                            (->> nodes
-                                 (filter #(satisfies? ThreadableData %))
-                                 (map #(step k % model))
-                                 (filter seq) flatten))
-                          [this] 
-                          ks))
-  (ld1-> [this ks] (first (ld-> this ks))))
-
-(nippy/extend-freeze 
- RDFResource ::rdf-resource
- [x data-output]
- (.writeUTF data-output (str x)))
-
-(nippy/extend-thaw 
- ::rdf-resource
- [data-input]
- (when-let [resource-iri (.readUTF data-input)]
-   (resource resource-iri)))
-
 (defn path [r]
   (let [uri (str resource)
         short-ns (names/curie uri)
@@ -198,7 +130,7 @@
   (fn [coll k v]
     (let [target (:genegraph.database.query/value (meta v))]
       (if (instance? Resource target)
-        (->RDFResource target model)
+        (types/->RDFResource target model)
         target))))
 
 (defn- substitute-known-iri-short-name [k-ns k]
@@ -218,62 +150,6 @@
 ;; TODO fix so that non-whitespace terminated expressions are treated appropriately
 (defn- expand-query-str [query-str]
   (s/replace query-str #":(\S+)/(\S+)" substitute-keyword))
-
-
-(def first-property (ResourceFactory/createProperty "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"))
-
-(defn rdf-list-to-vector [rdf-list-node model]
-
-  (let [rdf-list (.as rdf-list-node RDFList)]
-    (->> rdf-list .iterator iterator-seq (mapv #(to-clj % model)))
-    ))
-
-
-(defn- kw-to-property [kw]
-  (if-let [prop (names/local-property-names kw)]
-    prop
-    (when-let [ns (-> kw namespace prefix-ns-map)]
-      (ResourceFactory/createProperty (str ns (name kw))))))
-
-(extend-protocol Steppable
-
-  ;; Single keyword, treat as [:ns/prop :>] (outward pointing edge)
-  clojure.lang.Keyword
-  (step [edge start model]
-    (step [edge :>] start model))
-  
-  ;; Expect edge to be a vector with form [:ns/prop <direction>], where direction is one
-  ;; of :> :< :-
-  ;; TODO fail more gracefully when starting point is a literal
-  clojure.lang.IPersistentVector
-  (step [edge start model]
-    (tx 
-     (let [property (kw-to-property (first edge))
-           out-fn (fn [n] (->> (.listObjectsOfProperty model (.resource n) property)
-                               iterator-seq))
-           in-fn (fn [n] (->> (.listResourcesWithProperty model property (.resource n))
-                              iterator-seq))
-           both-fn #(concat (out-fn %) (in-fn %))
-           step-fn (case (second edge)
-                     :> out-fn
-                     :< in-fn
-                     :- both-fn)
-           result (mapv #(to-clj % model) (step-fn start))]
-       (case (count result)
-         0 nil
-         ;; 1 (first result)
-         result)))))
-
-(extend-protocol AsRDFNode
-
-  java.lang.String
-  (to-rdf-node [x] (ResourceFactory/createPlainLiteral x))
-  
-  clojure.lang.Keyword
-  (to-rdf-node [x] (local-names x))
-  
-  RDFResource
-  (to-rdf-node [x] (as-jena-resource x)))
 
 (defn- construct-query-solution-map [params]
   (let [qs-map (QuerySolutionMap.)]
@@ -315,7 +191,7 @@
                   model (if (instance? org.apache.jena.query.Dataset db-or-model)
                           (.getUnionModel db-or-model)
                           db-or-model)]
-              (mapv #(->RDFResource (.getResource % result-var) model) result-seq))))))))
+              (mapv #(types/->RDFResource (.getResource % result-var) model) result-seq))))))))
   
   java.lang.String
   (select 
@@ -332,24 +208,14 @@
                iri (if-let [iri-prefix (-> curie-prefix s/lower-case prefix-ns-map)]
                      (str iri-prefix rest)
                      r)]
-           (->RDFResource (ResourceFactory/createResource iri) (get-all-graphs))))
+           (types/->RDFResource (ResourceFactory/createResource iri) (get-all-graphs))))
     ([ns-prefix r] (when-let [prefix (prefix-ns-map ns-prefix)]
-                     (->RDFResource (ResourceFactory/createResource (str prefix r))
+                     (types/->RDFResource (ResourceFactory/createResource (str prefix r))
                                     (get-all-graphs)))))
   
   clojure.lang.Keyword
   (resource [r] (when-let [res (local-names r)]
-                  (->RDFResource res (get-all-graphs)))))
-
-(extend-protocol AsClojureType
-
-  Resource
-  (to-clj [x model] (if (.hasProperty x first-property)
-                      (rdf-list-to-vector x model)
-                      (->RDFResource x model)))
-  
-  Literal
-  (to-clj [x model] (.getValue x)))
+                  (types/->RDFResource res (get-all-graphs)))))
 
 (defn construct 
   ([query-string] (construct query-string {}))
@@ -392,7 +258,7 @@
                   (symbol? s) (Var/alloc (str s))
                   (keyword? s) (.asNode (local-class-names s))
                   (string? s) (NodeFactory/createURI s)
-                  (satisfies? AsJenaResource s) (.asNode (as-jena-resource s))
+                  (types/resource? o) (.asNode (as-jena-resource s))
                   :else (NodeFactory/createURI (str s)))
         predicate (cond
                     (instance? Node p) p
@@ -405,7 +271,7 @@
                  (or (string? o)
                      (int? o)
                      (float? o)) (.asNode (ResourceFactory/createTypedLiteral o))
-                 (satisfies? AsJenaResource o) (.asNode (as-jena-resource o))
+                 (types/resource? o) (.asNode (as-jena-resource o))
                  :else o)]
     (Triple. subject predicate object)))
 
@@ -492,7 +358,7 @@
           node-model (if (instance? Dataset model)
                        (get-all-graphs)
                        model)]
-      (mapv #(->RDFResource (.getResource % result-var) node-model) result-seq))))
+      (mapv #(types/->RDFResource (.getResource % result-var) node-model) result-seq))))
 
 (defn- exec [query-def params]
   (let [qs-map (construct-query-solution-map (medley/filter-keys #(nil? (namespace %)) params))

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -133,7 +133,14 @@
                                  (filter seq) flatten))
                           [this] 
                           ks))
-  (ld1-> [this ks] (first (ld-> this ks))))
+  (ld1-> [this ks] (first (ld-> this ks)))
+
+  Addressable
+  (path [_] (let [uri (.getURI resource)
+                  short-ns (names/curie uri)
+                  full-ns (prefix-ns-map short-ns)
+                  id (subs uri (count full-ns))]
+              (str "/r/" short-ns "_" id))))
 
 (defn- navize [model]
   (fn [coll k v]

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -1,30 +1,16 @@
 (ns genegraph.database.query.types
-  (:require [genegraph.database.instance :refer [db]]
-            [genegraph.database.util :as util :refer [tx]]
-            [genegraph.database.names :as names :refer
-             [local-class-names local-property-names
-              class-uri->keyword local-names ns-prefix-map
-              prefix-ns-map property-uri->keyword]]
-            [clojure.pprint :refer [pprint]]
-            [clojure.set :as set]
+  (:require [clojure.core.protocols :as protocols :refer [Datafiable]]
+            [clojure.datafy :as datafy :refer [datafy]]
             [clojure.string :as s]
-            [clojure.core.protocols :as protocols :refer [Datafiable]]
-            [clojure.datafy :as datafy :refer [datafy nav]]
-            [io.pedestal.log :as log]
-            [medley.core :as medley]
-            [clojure.java.io :as io]
+            [genegraph.database.instance :refer [db]]
+            [genegraph.database.names
+             :as
+             names
+             :refer
+             [class-uri->keyword local-names prefix-ns-map property-uri->keyword]]
+            [genegraph.database.util :as util :refer [tx]]
             [taoensso.nippy :as nippy])
-  (:import [org.apache.jena.rdf.model Model Statement ResourceFactory Resource Literal RDFList SimpleSelector ModelFactory]
-           [org.apache.jena.query Dataset QueryFactory Query QueryExecution
-            QueryExecutionFactory QuerySolutionMap]
-           [org.apache.jena.sparql.algebra AlgebraGenerator Algebra OpAsQuery Op]
-           [org.apache.jena.graph Node NodeFactory Triple Node_Variable Node_Blank]
-[org.apache.jena.sparql.algebra.op OpDistinct OpProject OpFilter OpBGP OpConditional OpDatasetNames OpDiff OpDisjunction OpDistinctReduced OpExtend OpGraph OpGroup OpJoin OpLabel OpLeftJoin OpList OpMinus OpNull OpOrder OpQuad OpQuadBlock OpQuadPattern OpReduced OpSequence OpSlice OpTopN OpUnion OpTable ]
-[org.apache.jena.sparql.core BasicPattern Var VarExprList QuadPattern Quad]
-           org.apache.jena.riot.writer.JsonLDWriter
-           org.apache.jena.sparql.core.Prologue
-           org.apache.jena.riot.RDFFormat$JSONLDVariant
-           java.io.ByteArrayOutputStream))
+  (:import [org.apache.jena.rdf.model Literal RDFList Resource ResourceFactory]))
 
 (def first-property (ResourceFactory/createProperty "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"))
 

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -1,0 +1,250 @@
+(ns genegraph.database.query.types
+  (:require [genegraph.database.instance :refer [db]]
+            [genegraph.database.util :as util :refer [tx]]
+            [genegraph.database.names :as names :refer
+             [local-class-names local-property-names
+              class-uri->keyword local-names ns-prefix-map
+              prefix-ns-map property-uri->keyword]]
+            [clojure.pprint :refer [pprint]]
+            [clojure.set :as set]
+            [clojure.string :as s]
+            [clojure.core.protocols :as protocols :refer [Datafiable]]
+            [clojure.datafy :as datafy :refer [datafy nav]]
+            [io.pedestal.log :as log]
+            [medley.core :as medley]
+            [clojure.java.io :as io]
+            [taoensso.nippy :as nippy])
+  (:import [org.apache.jena.rdf.model Model Statement ResourceFactory Resource Literal RDFList SimpleSelector ModelFactory]
+           [org.apache.jena.query Dataset QueryFactory Query QueryExecution
+            QueryExecutionFactory QuerySolutionMap]
+           [org.apache.jena.sparql.algebra AlgebraGenerator Algebra OpAsQuery Op]
+           [org.apache.jena.graph Node NodeFactory Triple Node_Variable Node_Blank]
+[org.apache.jena.sparql.algebra.op OpDistinct OpProject OpFilter OpBGP OpConditional OpDatasetNames OpDiff OpDisjunction OpDistinctReduced OpExtend OpGraph OpGroup OpJoin OpLabel OpLeftJoin OpList OpMinus OpNull OpOrder OpQuad OpQuadBlock OpQuadPattern OpReduced OpSequence OpSlice OpTopN OpUnion OpTable ]
+[org.apache.jena.sparql.core BasicPattern Var VarExprList QuadPattern Quad]
+           org.apache.jena.riot.writer.JsonLDWriter
+           org.apache.jena.sparql.core.Prologue
+           org.apache.jena.riot.RDFFormat$JSONLDVariant
+           java.io.ByteArrayOutputStream))
+
+(def first-property (ResourceFactory/createProperty "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"))
+
+(defprotocol Steppable
+  (step [edge start model]))
+
+(defprotocol AsReference
+  (to-ref [resource]))
+
+(defprotocol AsClojureType
+  (to-clj [x model]))
+
+(defprotocol AsRDFNode
+  (to-rdf-node [x]))
+
+(defprotocol Addressable
+  "Retrieves the local path to a resource"
+  (path [this]))
+
+(defprotocol ThreadableData
+  "A data structure that can be accessed through the ld-> and ld1-> accessors
+  similar to Clojure XML zippers"
+  (ld-> [this ks])
+  (ld1-> [this ks]))
+
+(defprotocol RDFType
+  (is-rdf-type? [this rdf-type]))
+
+(defprotocol AsJenaResource
+  (as-jena-resource [this]))
+
+(defprotocol AsResource
+  "Create an RDFResource given a reference"
+  (resource [r] [ns-prefix r]))
+
+(declare datafy-resource)
+
+(declare navize)
+
+(defn- compose-object-for-datafy [o]
+  (cond (instance? Literal o) (.toString o)
+        (instance? Resource o) 
+        (with-meta (-> o .toString symbol)
+          {::datafy/obj o
+           ::datafy/class (class o)
+           `protocols/datafy #(-> % meta ::datafy/obj datafy-resource)})))
+
+;; REFACTOR Would prefer to restructure RDFResource to take a nil model reference
+;; as a signal to use the default DB, rather than requiring each resource to include
+;; explicit reference. This is a placeholder until this can be accomplished
+(defn get-all-graphs []
+  (or @util/current-union-model (.getUnionModel db)))
+
+(deftype RDFResource [resource model]
+
+  AsJenaResource
+  (as-jena-resource [_] resource)
+
+  RDFType
+  (is-rdf-type? [this rdf-type] 
+    (let [t (if (= (type rdf-type) clojure.lang.Keyword) 
+              (local-names rdf-type)
+              (ResourceFactory/createResource rdf-type))]
+      (tx (.contains model resource (local-names :rdf/type) t))))
+
+  ;; TODO, returns all properties when k does not map to a known symbol,
+  ;; This seems to break the contract for ILookup
+  clojure.lang.ILookup
+  (valAt [this k] (step k this model))
+  (valAt [this k nf] nf)
+
+
+  ;; Conforms to the expectations for a sequence representation of a map. Includes only
+  ;; properties where this resource is the subject. Sequence is fully realized
+  ;; in order to permit access outside transaction
+  clojure.lang.Seqable
+  (seq [this]
+    (tx
+     (let [out-attributes (-> model (.listStatements resource nil nil) iterator-seq)]
+       (doall (map #(vector 
+                     (-> % .getPredicate property-uri->keyword)
+                     (to-clj (.getObject %) model)) out-attributes)))))
+
+  Object
+  (toString [_] (.getURI resource))
+  (equals [this other]
+    (and (satisfies? AsJenaResource other)
+         (= resource (as-jena-resource other))))
+  (hashCode [_] (.hashCode resource))
+  
+
+  AsReference
+  (to-ref [_] (class-uri->keyword resource))
+
+  Datafiable
+  (datafy [_] 
+    (tx 
+     (let [out-attributes (-> model (.listStatements resource nil nil) iterator-seq)
+           in-attributes (-> model (.listStatements nil nil resource) iterator-seq)]
+
+       (with-meta
+         (into [] (concat
+                   (mapv #(with-meta [[(-> % .getPredicate property-uri->keyword) :>]
+                                      (-> % .getObject compose-object-for-datafy)]
+                            {:genegraph.database.query/value  (.getObject %)})
+                         out-attributes)
+                   (mapv #(with-meta [[(-> % .getPredicate property-uri->keyword) :<]
+                                      (-> % .getSubject compose-object-for-datafy)]
+                            {:genegraph.database.query/value (.getSubject %)})
+                         in-attributes)))
+         {`protocols/nav (navize model)}))))
+
+  ;; TODO Flattening the ld-> has potentially undesirable behavior with RDFList, consider
+  ;; how flatten is being used in this context
+  ThreadableData
+  (ld-> [this ks] (reduce (fn [nodes k]
+                            (->> nodes
+                                 (filter #(satisfies? ThreadableData %))
+                                 (map #(step k % model))
+                                 (filter seq) flatten))
+                          [this] 
+                          ks))
+  (ld1-> [this ks] (first (ld-> this ks))))
+
+(defn- navize [model]
+  (fn [coll k v]
+    (let [target (:genegraph.database.query/value (meta v))]
+      (if (instance? Resource target)
+        (->RDFResource target model)
+        target))))
+
+(extend-protocol AsResource
+  
+  java.lang.String
+  (resource 
+    ([r] (let [[_ curie-prefix rest] (re-find #"^([a-zA-Z]+)[:_](.*)$" r)
+               iri (if-let [iri-prefix (-> curie-prefix s/lower-case prefix-ns-map)]
+                     (str iri-prefix rest)
+                     r)]
+           (->RDFResource (ResourceFactory/createResource iri) (get-all-graphs))))
+    ([ns-prefix r] (when-let [prefix (prefix-ns-map ns-prefix)]
+                     (->RDFResource (ResourceFactory/createResource (str prefix r))
+                                    (get-all-graphs)))))
+  
+  clojure.lang.Keyword
+  (resource [r] (when-let [res (local-names r)]
+                  (->RDFResource res (get-all-graphs)))))
+
+(nippy/extend-freeze 
+ RDFResource ::rdf-resource
+ [x data-output]
+ (.writeUTF data-output (str x)))
+
+(nippy/extend-thaw 
+ ::rdf-resource
+ [data-input]
+ (when-let [resource-iri (.readUTF data-input)]
+   (resource resource-iri)))
+
+(defn- kw-to-property [kw]
+  (if-let [prop (names/local-property-names kw)]
+    prop
+    (when-let [ns (-> kw namespace prefix-ns-map)]
+      (ResourceFactory/createProperty (str ns (name kw))))))
+
+(extend-protocol Steppable
+
+  ;; Single keyword, treat as [:ns/prop :>] (outward pointing edge)
+  clojure.lang.Keyword
+  (step [edge start model]
+    (step [edge :>] start model))
+  
+  ;; Expect edge to be a vector with form [:ns/prop <direction>], where direction is one
+  ;; of :> :< :-
+  ;; TODO fail more gracefully when starting point is a literal
+  clojure.lang.IPersistentVector
+  (step [edge start model]
+    (tx 
+     (let [property (kw-to-property (first edge))
+           out-fn (fn [n] (->> (.listObjectsOfProperty model (.resource n) property)
+                               iterator-seq))
+           in-fn (fn [n] (->> (.listResourcesWithProperty model property (.resource n))
+                              iterator-seq))
+           both-fn #(concat (out-fn %) (in-fn %))
+           step-fn (case (second edge)
+                     :> out-fn
+                     :< in-fn
+                     :- both-fn)
+           result (mapv #(to-clj % model) (step-fn start))]
+       (case (count result)
+         0 nil
+         ;; 1 (first result)
+         result)))))
+
+(defn resource?
+  "Return true if the object is an RDFResource"
+  [r]
+  (satisfies? AsJenaResource r))
+
+(extend-protocol AsRDFNode
+
+  java.lang.String
+  (to-rdf-node [x] (ResourceFactory/createPlainLiteral x))
+  
+  clojure.lang.Keyword
+  (to-rdf-node [x] (local-names x))
+  
+  RDFResource
+  (to-rdf-node [x] (as-jena-resource x)))
+
+(defn- rdf-list-to-vector [rdf-list-node model]
+  (let [rdf-list (.as rdf-list-node RDFList)]
+    (->> rdf-list .iterator iterator-seq (mapv #(to-clj % model)))))
+
+(extend-protocol AsClojureType
+
+  Resource
+  (to-clj [x model] (if (.hasProperty x first-property)
+                      (rdf-list-to-vector x model)
+                      (->RDFResource x model)))
+  
+  Literal
+  (to-clj [x model] (.getValue x)))

--- a/src/genegraph/source/graphql/gene_dosage.clj
+++ b/src/genegraph/source/graphql/gene_dosage.clj
@@ -1,7 +1,7 @@
 (ns genegraph.source.graphql.gene-dosage
   (:require [clojure.string :as string]
             [genegraph.database.names :as names]
-            [genegraph.database.query :as q :refer [->RDFResource]]
+            [genegraph.database.query :as q]
             [genegraph.source.graphql.common.cache :refer [defresolver]]
             [com.walmartlabs.lacinia.schema :refer [tag-with-type]]
             [genegraph.database.instance :refer [db]])

--- a/src/genegraph/source/html/elements/domain_model.clj
+++ b/src/genegraph/source/html/elements/domain_model.clj
@@ -65,7 +65,7 @@
         [:div.column.has-text-right [:code property]]
         [:div.column.has-text-left
          [:code
-          (if (satisfies? q/AsJenaResource value)
+          (if (q/resource? value)
             (e/link value))]]])]))
 
 (defmethod e/page :shacl/NodeShape [shape]


### PR DESCRIPTION
Major refactoring of the query namespace. the 'public' api is presented through query.clj, the implementation of this has mostly been pushed up into three separate namespaces (types, resource, and algebra). Anticipates addition of filter-op to the query algebra.