### PR TITLE
Don't import non-publish events, change interceptors to avoid race

### DIFF
--- a/src/genegraph/annotate/action.clj
+++ b/src/genegraph/annotate/action.clj
@@ -4,7 +4,7 @@
 (defmulti add-action :genegraph.transform.core/format)
 
 (defmethod add-action :default [event]
-  event)
+  (assoc event :genegraph.annotate/action :publish))
 
 (defmethod add-action :gci-legacy [event]
   (let [report-json (json/parse-string (:genegraph.sink.event/value event) true)]

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -50,7 +50,6 @@
     (base/initialize-db!)
     (start #'suggest/suggestions)
     (suggest/build-all-suggestions)
-    (start #'event/interceptor-context)
     (batch/process-batched-events!)
     (start #'stream/consumer-thread)
     (log/debug :fn :build-database :msg "Starting streams...")
@@ -67,7 +66,6 @@
     (warm-resolver-cache)
     (stop #'cache/resolver-cache-db)
     (stop #'suggest/suggestions)
-    (stop #'event/interceptor-context)
     (stop #'db/db)))
 
 (defn compress-database

--- a/src/genegraph/source/graphql/actionability.clj
+++ b/src/genegraph/source/graphql/actionability.clj
@@ -5,12 +5,17 @@
 (defresolver actionability-query [args value]
   (q/resource (:iri args)))
 
+(def report-date-query 
+  (q/create-query 
+   (str "select ?contribution where "
+        " { ?report :sepio/qualified-contribution ?contribution . "
+        "   ?contribution :bfo/realizes :sepio/EvidenceRole . "
+        "   ?contribution :sepio/activity-date ?date } "
+        " order by desc(?date) "
+        " limit 1 ")))
+
 (defresolver report-date [args value]
-  (->
-   (q/ld-> value 
-           [:sepio/qualified-contribution :sepio/activity-date])
-   sort
-   last))
+  (some-> (report-date-query {:report value}) first :sepio/activity-date first))
 
 (defresolver report-id [args value]
   (->> value str (re-find #"\w+$")))


### PR DESCRIPTION
Two things:

* changed the add-to-db to only publish records labelled for publication
* Changed the interceptor creation to avoid using atom/global state

Added a third:

* changed the actionability report date to reflect the last searched date.

On the last bit, was concerned about a race condition, where one event could update the context for an interceptor, followed by another event doing the same, causing the second event to fire twice and the first not at all.

Haven't observed this in the wild, but it definitely looks possible. No reason to risk it when a clean refactor is available.

Also changed the constructor to work with objects directly, rather than translating keywords to symbols. Figure that this lets us use the full diversity of interceptors...