### PR TITLE
Replace gcie curation

### DIFF
--- a/resources/batch-events.edn
+++ b/resources/batch-events.edn
@@ -1,2 +1,7 @@
 [{:name "gci-neo4j-archive"
-  :source "gci-neo4j-archive.tar.gz"}]
+  :source "gci-neo4j-archive.tar.gz"
+  :type :compressed-event-files}
+ {:name "gci-express-json"
+  :source "ClinGen-Gene-Expess-Data-01092020.json"
+  :type :json-event-sequence
+  :format :gci-express}]

--- a/resources/class-names.edn
+++ b/resources/class-names.edn
@@ -70,6 +70,7 @@
  [:cg/DomainModel "http://dataexchange.clinicalgenome.org/terms/DomainModel"]
  [:cg/ActionabilityGeneticCondition "http://dataexchange.clinicalgenome.org/terms/ActionabilityGeneticCondition"]
  [:cg/Affiliation "http://dataexchange.clinicalgenome.org/terms/Affiliation"]
+ [:cg/GeneCurationExpress "http://dataexchange.clinicalgenome.org/terms/GeneCurationExpress"]
  [:so/ProteinCodingGene "http://purl.obolibrary.org/obo/SO_0001217"]
  [:so/SequenceFeature "http://purl.obolibrary.org/obo/SO_0000110"]
  [:sepio/GeneDosageReport "http://purl.obolibrary.org/obo/SEPIO_0002015"]

--- a/resources/formats.edn
+++ b/resources/formats.edn
@@ -15,6 +15,9 @@
  :gci-legacy  {:genegraph.transform.core/format :gci-legacy
                :genegraph.annotate/root-type :sepio/GeneValidityReport
                :genegraph.annotate/graph-name :sepio/GeneValidityProposition}
+ :gci-express  {:genegraph.transform.core/format :gci-express
+                :genegraph.annotate/root-type :sepio/GeneValidityReport
+                :genegraph.annotate/graph-name :sepio/GeneValidityProposition}
  :gene-validity-neo4j-export {:genegraph.transform.core/format :gene-validity-neo4j-export
                               :genegraph.annotate/root-type :sepio/GeneValidityReport
                               :genegraph.annotate/graph-name :sepio/GeneValidityProposition}

--- a/src/genegraph/annotate.clj
+++ b/src/genegraph/annotate.clj
@@ -119,8 +119,11 @@
   (if-let [gv-prop (first (q/select "select ?s where { ?s a :sepio/GeneValidityProposition }" {}
                                     (::q/model event)))]
     (let [genes (q/ld-> gv-prop [:sepio/has-subject])
-          diseases (q/ld-> gv-prop [:sepio/has-object])]
-      (add-subjects-to-event event genes diseases))
+          diseases (q/ld-> gv-prop [:sepio/has-object])
+          modes-of-inheritance (q/ld-> gv-prop [:sepio/has-qualifier])]
+      (assoc event ::subjects {:gene-iris (mapv str genes)
+                               :disease-iris (mapv str diseases)
+                               :moi-iris (mapv str modes-of-inheritance)}))
     event))
 
 (defmethod add-subjects :default [event]

--- a/src/genegraph/annotate.clj
+++ b/src/genegraph/annotate.clj
@@ -1,5 +1,6 @@
 (ns genegraph.annotate
   (:require [genegraph.annotate.action :as action]
+            [genegraph.annotate.replaces :as replaces]
             [genegraph.database.query :as q]
             [genegraph.database.validation :as validate]
             [genegraph.database.util :as util :refer [tx]]
@@ -134,3 +135,10 @@
   "Interceptor adding a subject annotation (gene/disease iris) to stream events"
   (interceptor-enter-def ::add-subjects add-subjects))
 
+(defn add-replaces [event]
+  (replaces/add-replaces event))
+
+(def add-replaces-interceptor
+  "Interceptor checking to see if an incoming curation should replace any existing records"
+  {:name ::add-replaces-interceptor
+   :enter add-replaces})

--- a/src/genegraph/annotate/replaces.clj
+++ b/src/genegraph/annotate/replaces.clj
@@ -1,0 +1,30 @@
+(ns genegraph.annotate.replaces
+  (:require [genegraph.database.query :as q]))
+
+(defmulti add-replaces :genegraph.annotate/format)
+
+(defmethod add-replaces :default [event]
+  event)
+
+(def find-old-gci-express-curation 
+  (q/create-query 
+   (str "select ?proposition where { "
+        " ?report a :sepio/GeneValidityReport . "
+        " ?report :dc/source :cg/GeneCurationExpress ."
+        " ?report :bfo/has-part ?assertion ."
+        " ?assertion a :sepio/GeneValidityEvidenceLevelAssertion . "
+        " ?assertion :sepio/has-subject ?proposition ."
+        " ?proposition :sepio/has-subject ?gene ."
+        " ?proposition :sepio/has-qualifier ?moi ."
+        " ?proposition :sepio/has-object ?disease . }")))
+
+(defmethod add-replaces :gene-validity [event]
+  (let [subjects (:genegraph.annotate/subjects event)
+        old-gci-express-curation (first
+                                  (find-old-gci-express-curation
+                                   {:gene (q/resource (-> subjects :gene-iris first))
+                                    :disease (q/resource (-> subjects :disease-iris first))
+                                    :moi (q/resource (-> subjects :moi-iris first))}))]
+    (if old-gci-express-curation
+      (assoc event :genegraph.annotate/replaces old-gci-express-curation)
+      event)))

--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -49,14 +49,27 @@
   {:name ::unpublish
    :enter unpublish})
 
+(defn replace-curation
+  [event]
+  (when (::ann/replaces event)
+    (log/info :fn ::replace :root-type (::ann/root-type event) :iri (str (::ann/replaces event)))
+    (remove-model (str (::ann/replaces event))))
+  event)
+
+(def replace-interceptor
+  {:name ::replace
+   :enter replace-curation})
+
 (def interceptor-chain [ann/add-metadata-interceptor
                         ann/add-model-interceptor
                         ann/add-iri-interceptor
                         ann/add-validation-interceptor
                         ann/add-subjects-interceptor
                         ann/add-action-interceptor
+                        ann/add-replaces-interceptor
                         add-to-db-interceptor
                         unpublish-interceptor
+                        replace-interceptor
                         suggest/update-suggesters-interceptor
                         cache/expire-resolver-cache-interceptor
                         response-cache/expire-response-cache-interceptor])

--- a/src/genegraph/transform/gci_express.clj
+++ b/src/genegraph/transform/gci_express.clj
@@ -80,7 +80,8 @@
     (concat [[iri :rdf/type :sepio/GeneValidityReport] 
              [iri :rdfs/label (:title content)]
              [iri :bfo/has-part content-id]
-             [iri :bfo/has-part assertion-id]]
+             [iri :bfo/has-part assertion-id]
+             [iri :dc/source :cg/GeneCurationExpress]]
             (evidence-level-assertion content assertion-id id)
             (json-content-node content content-id))))
 
@@ -94,4 +95,4 @@
   (assoc event
          :genegraph.database.query/model
          (l/statements-to-model (gci-express-report-to-triples
-                                 (json/parse-string (:genegraph.sink.event/value event))))))
+                                 (:genegraph.sink.event/value event)))))

--- a/src/genegraph/transform/gci_express.clj
+++ b/src/genegraph/transform/gci_express.clj
@@ -1,7 +1,7 @@
 (ns genegraph.transform.gci-express
   (:require [genegraph.database.load :as l]
             [genegraph.database.query :as q :refer [resource]]
-            [genegraph.transform.core :refer [transform-doc src-path]]
+            [genegraph.transform.core :refer [transform-doc src-path add-model]]
             [cheshire.core :as json]))
 
 (def gci-express-root "http://dataexchange.clinicalgenome.org/gci-express/")
@@ -88,3 +88,10 @@
   (let [raw-report (or (:document doc-def) (slurp (src-path doc-def)))
         report-json (json/parse-string raw-report true)]
     (l/statements-to-model (mapcat gci-express-report-to-triples report-json))))
+
+
+(defmethod add-model :gci-express [event]
+  (assoc event
+         :genegraph.database.query/model
+         (l/statements-to-model (gci-express-report-to-triples
+                                 (json/parse-string (:genegraph.sink.event/value event))))))

--- a/test/genegraph/server_test.clj
+++ b/test/genegraph/server_test.clj
@@ -195,4 +195,33 @@
           (event/process-event! (second (:gene-validity-unpublish-sequence events)))
           (is (= 0 
                  (count (get-in (query gene-query {:iri gene}) 
-                                [:json :data :gene :genetic_conditions])))))))))
+                                [:json :data :gene :genetic_conditions]))))))
+      (testing "Test gci-express update sequence"
+        (let [gene (-> events 
+                       :gci-express-update-sequence
+                       first
+                       annotate-event
+                       ::ann/subjects
+                       :gene-iris
+                       first)]
+          (println gene)
+          (is (= 0 (count (get-in (query gene-query {:iri gene}) 
+                                  [:json :data :gene :genetic_conditions]))))
+          (event/process-event! (first (:gci-express-update-sequence events)))
+          (is (= 1 
+                 (count (:gene_validity_assertions
+                         (first 
+                          (get-in (query gene-query {:iri gene}) 
+                                  [:json
+                                   :data
+                                   :gene
+                                   :genetic_conditions]))))))
+          (event/process-event! (second (:gci-express-update-sequence events)))
+          (is (= 1 
+                 (count (:gene_validity_assertions
+                         (first 
+                          (get-in (query gene-query {:iri gene}) 
+                                  [:json
+                                   :data
+                                   :gene
+                                   :genetic_conditions])))))))))))


### PR DESCRIPTION
Adds feature to allow new GCI curations to replace old GCI-express curations with the same disease, gene, and MOI. Testing of this feature has been integrated into the PR.