### PR TITLE
Adding rule-outs to ac assertions, option for non-distinct query

### DIFF
--- a/resources/class-names.edn
+++ b/resources/class-names.edn
@@ -297,17 +297,19 @@
  [:sepio/DefinitiveActionability
   "http://purl.obolibrary.org/obo/SEPIO_0003535"]
  [:sepio/StrongActionability
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
+  "http://purl.obolibrary.org/obo/SEPIO_0003536"]
  [:sepio/ModerateActionability
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
+  "http://purl.obolibrary.org/obo/SEPIO_0003537"]
  [:sepio/LimitedActionability
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
- [:sepio/InsufficientActionability
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
+  "http://purl.obolibrary.org/obo/SEPIO_0003538"]
+ [:sepio/InsufficientEvidenceForActionabilityEarlyRuleOut
+  "http://purl.obolibrary.org/obo/SEPIO_0003539"]
  [:sepio/NoActionability
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
+  "http://purl.obolibrary.org/obo/SEPIO_0003540"]
  [:sepio/AssertionPending
-  "http://purl.obolibrary.org/obo/SEPIO_0003013"]
+  "http://purl.obolibrary.org/obo/SEPIO_0003541"]
+ [:sepio/InsufficientEvidenceForActionabilityExpertReview
+  "http://purl.obolibrary.org/obo/SEPIO_0003542"]
  [:void/Dataset "http://rdfs.org/ns/void#Dataset"]
  [:chebi/Drug "http://purl.obolibrary.org/obo/CHEBI_23888"]]
 

--- a/resources/kafka.edn
+++ b/resources/kafka.edn
@@ -52,6 +52,10 @@
                                       :name "gene_validity"
                                       :root-type :sepio/GeneValidityReport
                                       :cluster :dx-prod}
+            :gci-legacy-devold-cluster  {:format :gci-legacy
+                                         :name "gene_validity_dev"
+                                         :root-type :sepio/GeneValidityReport
+                                         :cluster :dx-prod}
             :gene-validity-events-dev {:name "gene_validity_events_dev"
                                        :cluster :dx-ccloud}
             :clinvar-raw {:name "clinvar-raw"

--- a/src/genegraph/database/query/resource.clj
+++ b/src/genegraph/database/query/resource.clj
@@ -219,5 +219,7 @@ use io/slurp"
                                           (slurp query-source)))))]
      (case (:genegraph.database.query/type params)
        :ask (.setQueryAskType query)
-       (.setDistinct query true))
+       (if  (:genegraph.database.query/distinct params true)
+         (.setDistinct query true)
+         query))
      (->StoredQuery query))))

--- a/src/genegraph/transform/actionability.clj
+++ b/src/genegraph/transform/actionability.clj
@@ -39,6 +39,7 @@
    "Moderate Actionability" "http://purl.obolibrary.org/obo/SEPIO_0003537"
    "Limited Actionability" "http://purl.obolibrary.org/obo/SEPIO_0003538"
    "Insufficient Actionability" "http://purl.obolibrary.org/obo/SEPIO_0003539"
+   "Insufficient Evidence" "http://purl.obolibrary.org/obo/SEPIO_0003539"
    "No Actionability" "http://purl.obolibrary.org/obo/SEPIO_0003540"
    "Assertion Pending" "http://purl.obolibrary.org/obo/SEPIO_0003541"
    
@@ -98,10 +99,17 @@
        (map #(vector (:iri curation) :cg/has-total-actionability-score %))))
 
 (defn assertions [curation]
-  (let [assertion-set (if (:assertions curation)
-                        (into #{} (:assertions curation))
-                        (into #{} (map #(assoc % :assertion "Assertion Pending")
-                                       (:conditions curation))))]
+  (let [assertion-set
+        (cond 
+          (:assertions curation)
+          (into #{} (:assertions curation))
+          
+          (= "Failed" (:earlyRuleOutStatus curation))
+          (into #{} (map #(assoc % :assertion "Insufficient Evidence")
+                         (:conditions curation)))
+          :else
+          (into #{} (map #(assoc % :assertion "Assertion Pending")
+                         (:conditions curation))))]
     (mapcat #(assertion (:iri curation) %) assertion-set)))
 
 (defn transform [curation]


### PR DESCRIPTION
* Adding ruleout status to actionability assertion
* Adding option to forgo distinct when using `genegraph.database.query/create-query`