### PR TITLE
Adding actionability sepio models to base

### DIFF
--- a/resources/base.edn
+++ b/resources/base.edn
@@ -78,6 +78,16 @@
   :target "sepio-clingen-actionability-shapes.ttl"
   :format :rdf
   :reader-opts {:format :turtle}}
+  {:name "http://purl.obolibrary.org/obo/sepio-clingen-actionability"
+  :source "https://raw.githubusercontent.com/clingen-data-model/SEPIO-ontology/master/src/ontology/extensions/clingen/clingen-actionability/sepio-clingen-actionability.ttl"
+  :target "sepio-clingen-actionability.ttl"
+  :format :rdf
+   :reader-opts {:format :turtle}}
+  {:name "http://dataexchange.clinicalgenome.org/models/sepio-clingen-actionability-valueset"
+  :source "https://raw.githubusercontent.com/clingen-data-model/SEPIO-ontology/master/src/ontology/extensions/clingen/clingen-actionability/sepio-clingen-actionability-valueset.ttl"
+  :target "sepio-clingen-actionability-valueset.ttl"
+  :format :rdf
+  :reader-opts {:format :turtle}}
  {:name "http://purl.obolibrary.org/obo/sepio-valueset.owl"
   :source "https://raw.githubusercontent.com/tnavatar/SEPIO-ontology/master/src/ontology/sepio-valueset.owl" 
   :target "sepio-valueset.owl"

--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -76,7 +76,9 @@
 
 (def log-result-interceptor
   {:name ::log-result
-   :leave (fn [e] (log/info :fn :log-result-interceptor :event e) e)})
+   :leave (fn [e] (log/info
+                   :fn :log-result-interceptor
+                   :event (select-keys e [::ann/iri ::ann/subjects])) e)})
 
 (def interceptor-chain [log-result-interceptor
                         write-tx-interceptor

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -155,3 +155,6 @@
          (csv/write-csv w))))
 
 ;; (->> gd-stream-with-model (remove ::spec/invalid) annotate-stream-with-full-data first ::ann/iri)
+;; (def gv-neo (->> "/Users/tristan/data/genegraph/2021-01-26T1745/events/gci-neo4j-archive" io/file file-seq (filter #(.isFile %)) (map #(-> % slurp edn/read-string))))
+
+;; (-> "/Users/tristan/data/genegraph/2021-01-26T2232/events/gci-neo4j-archive/98cb808e-02d3-4378-8e6b-9b1b2883cc65.edn" slurp edn/read-string event/process-event!)


### PR DESCRIPTION
Small PR, just forgot to get the actionability stuff in the base load. realized I needed this when exposing actionability data via GraphQL