### PR TITLE
Freeze thaw bnodes

### DIFF
--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -19,8 +19,10 @@
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.java.io :as io]
-            [clojure.edn :as edn])
-  (:import java.time.Instant))
+            [clojure.edn :as edn]
+            [taoensso.nippy :as nippy])
+  (:import java.time.Instant
+           org.apache.jena.rdf.model.AnonId))
 
 (defn start-rebl []
   (rebl/ui))


### PR DESCRIPTION
Using the resolver cache with blank node values generates an error on access. This is due to blank nodes not having a URI and presenting a null value when getURI is called.

This addresses the problem by serializing the bnode by the guid automatically generated by Jena as an identifier. This requires different handling than URI-identified nodes, and so logic is added to the extensions to freeze/unfreeze for RDF Resources to handle this use case.

Once this code is added, blank nodes serialize appropriately when added to the rocksDB cache.