### PR TITLE
Adding website display label to MOI

### DIFF
--- a/resources/graphql-schema.edn
+++ b/resources/graphql-schema.edn
@@ -229,7 +229,10 @@
                       :description "CURIE of the IRI representing this resource."}
               :label {:type String
                       :resolve :resource/label
-                      :description "Label for the condition."}}}
+                      :description "Label for the resource."}
+              :website_display_label {:type String
+                                      :resolve :resource/label
+                                      :description "Label used to display resource on the ClinGen Website. In general will correspond with the standard label for the resource, but may include overrides based on the specific display needs of the website."}}}
 
 
     :Disease


### PR DESCRIPTION
Adding the display label to the website so that Phil can implement his changes. Still need to implement the override in Genegraph, but at least this way he'll have the field in the schema available.

This may be one of the rare PRs that can be deployed without a complete rebuild of the database.