### PR TITLE
One write-tx per record batch test

### DIFF
--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -92,7 +92,6 @@
               e))})
 
 (def interceptor-chain [log-result-interceptor
-                        write-tx-interceptor
                         ann/add-metadata-interceptor
                         ann/add-model-interceptor
                         ann/add-iri-interceptor

--- a/src/genegraph/sink/stream.clj
+++ b/src/genegraph/sink/stream.clj
@@ -2,6 +2,7 @@
   (:require [genegraph.sink.event :as event]
             [genegraph.annotate :as annotate]
             [genegraph.env :as env]
+            [genegraph.database.util :refer [write-tx]]
             [clojure.java.io :as io]
             [mount.core :refer [defstate]]
             [clojure.edn :as edn]
@@ -102,13 +103,15 @@
             (.seekToBeginning consumer [part])))
         (read-end-offsets! consumer tp)
         (while @run-consumer
-          (doseq [record (poll-once consumer)]
-            (try
-              (-> record (consumer-record-to-clj topic) event/process-event!)
-              (catch Exception e
-                (log/info :fn :assign-topic! :topic topic :msg (str "Caught exception " (.getMessage e))
-                          :exception e)))
-            (update-offsets! consumer tp)))
+          (let [records (poll-once consumer)]
+            (write-tx
+             (doseq [record records]
+               (try
+                 (-> record (consumer-record-to-clj topic) event/process-event!)
+                 (catch Exception e
+                   (log/info :fn :assign-topic! :topic topic :msg (str "Caught exception " (.getMessage e))
+                             :exception e)))
+               (update-offsets! consumer tp)))))
         (swap! topic-state assoc topic :stopped)))))
 
 (defn up-to-date? 

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -42,6 +42,13 @@
   (doseq [event event-seq]
     (event/process-event! event)))
 
+(defn process-event-seq-one-transaction
+  "Run event sequence through event processor"
+  [event-seq]
+  (write-tx
+   (doseq [event event-seq]
+     (event/process-event! (assoc event ::event/dont-open-tx true)))))
+
 (defn process-event-dry-run
   "Run event through event processor, do not create side effects"
   [event]


### PR DESCRIPTION
Each call to poll Kafka results in a batch of records being pulled. By wrapping the processing of this batch in a single write transaction, we substantially reduce the number of write transactions being called in order to build the database.

Admittedly, builds are still pretty slow (last one took 70m), but very little of this time is spent processing records off the stream now (approximately 2m during the last run). Of the remaining time:

~23m on building the base data (RxNORM is a disproportionate offender here). Starting from a common base could eliminate this time.
~22m warming the resolver caches (possibly this can be parallelized for some speed improvements)
~19m building the suggesters (maybe this can be optimized, or at a minimum run parallel to the resolver build)
~3.5m compressing the database.

There's still room for improvement, but I think this hits the target. In an isolated test, adding the data from Actionability went from ~4m to ~4s running in a single transaction. It's possible to contemplate loading all the data from ClinVar in hours rather than days with this level of performance.

Worth mentioning is that the time spent processing and transforming the data never exceeded 20% of the time needed to write the data to the database. Since writes can't be run in parallel, there is little benefit in further parallelizing the build process, especially given the complexity of handling a core.async based pipeline. It may be feasible to parallelize some processing using futures (but only when there is no dependency on data already written from the stream, since transactions are thread-local the future won't have access to data already written.)