### PR TITLE
GCI data integration checkpoint

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,11 +23,12 @@
                  [org.apache.jena/jena-core "3.14.0"]
                  [org.apache.jena/jena-iri "3.14.0"]
                  [org.apache.lucene/lucene-suggest "7.4.0"] ;; jena 3.14.0 includes lucene 7.4.0
-                 [org.topbraid/shacl "1.1.0"]
+                 ;; Dependency superceeded by antlr provided via lacinia dependency
+                 [org.topbraid/shacl "1.3.2" :exclusions [org.antlr/antlr4-runtime]]
                  [mount "0.1.16"]
                  [com.velisco/clj-ftp "0.3.9"] ;; For downloading ftp docs
                  [clj-http "3.9.1"] ;; For downloading 
-                 [com.walmartlabs/lacinia-pedestal "0.14.0"]
+                 [com.walmartlabs/lacinia-pedestal "0.15.0"]
                  [clj-commons/fs "1.5.2"]
                  ;; Dirwatch for updating base files in development
                  [juxt/dirwatch "0.2.5"]

--- a/resources/formats.edn
+++ b/resources/formats.edn
@@ -13,8 +13,12 @@
  :gene-validity  {:genegraph.transform.core/format :gci-legacy
                   :genegraph.annotate/root-type :sepio/GeneValidityReport
                   :genegraph.annotate/graph-name :sepio/GeneValidityProposition}
- :gene-validity-raw {:genegraph.transform.core/format :gci-legacy}
- :gene-validity-raw-dev {:genegraph.transform.core/format :gci-legacy}
+ :gene-validity-raw {:genegraph.transform.core/format :gci-refactor
+                     :genegraph.annotate/root-type :sepio/GeneValidityProposition
+                     :genegraph.annotate/graph-name :sepio/GeneValidityProposition}
+ :gene-validity-raw-dev {:genegraph.transform.core/format :gci-refactor
+                         :genegraph.annotate/root-type :sepio/GeneValidityProposition
+                         :genegraph.annotate/graph-name :sepio/GeneValidityProposition}
  :gci-legacy  {:genegraph.transform.core/format :gci-legacy
                :genegraph.annotate/root-type :sepio/GeneValidityReport
                :genegraph.annotate/graph-name :sepio/GeneValidityProposition}

--- a/resources/shapes.edn
+++ b/resources/shapes.edn
@@ -4,5 +4,14 @@
 ;; The map value is itself a map, containing a :graph-name key which directly relates to
 ;; a :name key in base.edn - that is, a shacl model that has been previously loaded into the db.
 ;; To turn off validations, define an empty map here.
-{:sepio/GeneDosageReport {:graph-name "http://dataexchange.clinicalgenome.org/models/sepio-clingen-dosage-shapes.ttl"}}
+{:sepio/GeneDosageReport
+ {:graph-name "http://dataexchange.clinicalgenome.org/models/sepio-clingen-dosage-shapes.ttl"
+  :validation-context
+  ["http://purl.obolibrary.org/obo/sepio-clingen-dosage-valueset"
+   "http://purl.obolibrary.org/obo/sepio-clingen-dosage.owl"]}
+ :sepio/GeneValidityProposition
+ {:graph-name "http://purl.obolibrary.org/obo/sepio-clingen-gene-validity-shapes"
+  :validation-context
+  ["http://purl.obolibrary.org/obo/sepio-clingen-gene-validity"
+   "http://purl.obolibrary.org/obo/sepio-clingen-gene-validity-valueset"]}}
 

--- a/src/genegraph/annotate.clj
+++ b/src/genegraph/annotate.clj
@@ -87,13 +87,9 @@
   "Annotate the event with the result of any configured Shacl validation"
   [event]
   (if (::validation-shape event)
-    (let [shape-model (::validation-shape event)
-          data-model (::q/model event)
-          validation-result (validate/validate data-model shape-model)
-          did-validate (validate/did-validate? validation-result)
-          turtle (q/to-turtle validation-result)
-          iri (::iri event)
-          root-type (::root-type event)]
+    (let [validation-result (validate/validate (::q/model event)
+                                               (::validation-shape event))
+          did-validate (validate/did-validate? validation-result)]
       (assoc event ::validation validation-result ::did-validate did-validate))
     event))
 

--- a/src/genegraph/annotate.clj
+++ b/src/genegraph/annotate.clj
@@ -63,25 +63,39 @@
   "Interceptor adding model annotation to stream events"
   (interceptor-enter-def ::add-model add-model))
 
+(defn add-validation-shape
+  "Annotate the event with the appropriate shape for validation
+  if it exists in the database and if a shape has not already been
+  added (during development, for example)."
+  [event]
+  (if (and env/validate-events
+           (not (::validation-shape event)))
+    (assoc event
+           ::validation-shape
+           (some-> event
+                   ::root-type
+                   shapes
+                   :graph-name
+                   q/get-named-graph))
+    event))
+
+(def add-validation-shape-interceptor
+  {:name ::add-validation-shape
+   :enter add-validation-shape})
+
 (defn add-validation
   "Annotate the event with the result of any configured Shacl validation"
   [event]
-  (log/debug :fn :add-validation :event event :msg :received-event)
-  (when (and (some? shapes)
-             (true? (Boolean/valueOf env/validate-events)))
-    (let [shape-doc-def (-> event ::root-type shapes)]
-      (when (some? shape-doc-def)
-        (tx
-         (let [shape-model (q/get-named-graph (:graph-name shape-doc-def))
-               data-model (::q/model event)
-               validation-result (validate/validate data-model shape-model)
-               did-validate (validate/did-validate? validation-result)
-               turtle (q/to-turtle validation-result)
-               iri (::iri event)
-               root-type (::root-type event)]
-           (log/debug :fn :add-validation :root-type root-type :iri iri :did-validate? did-validate :report turtle)
-           (assoc event ::validation validation-result ::did-validate did-validate))))))
-  event)
+  (if (::validation-shape event)
+    (let [shape-model (::validation-shape event)
+          data-model (::q/model event)
+          validation-result (validate/validate data-model shape-model)
+          did-validate (validate/did-validate? validation-result)
+          turtle (q/to-turtle validation-result)
+          iri (::iri event)
+          root-type (::root-type event)]
+      (assoc event ::validation validation-result ::did-validate did-validate))
+    event))
 
 (def add-validation-interceptor
   "Interceptor adding shacl validation to stream events.
@@ -89,8 +103,7 @@
  {:name ::add-validation
   :enter (fn [context] (let [evt (add-validation context)]
                          (if (false? (::did-validate evt))
-                           ;; TODO May want to take a different action here...
-                           (terminate context)
+                           (terminate evt)
                            evt)))})
 
 (defn add-subjects-to-event

--- a/src/genegraph/database/load.clj
+++ b/src/genegraph/database/load.clj
@@ -25,10 +25,8 @@
 
 (defn read-rdf
   ([src] (read-rdf src {}))
-  ([src opts] (try
-                (-> (ModelFactory/createDefaultModel)
-                    (.read src nil (jena-rdf-format (:format opts :rdf-xml))))
-                (catch Exception e (log/error :fn :read-rdf :src src :msg (.message e)))))) 
+  ([src opts] (-> (ModelFactory/createDefaultModel)
+                  (.read src nil (jena-rdf-format (:format opts :rdf-xml)))))) 
 
 (defn store-rdf 
   "Expects src to be compatible with Model.read(src, nil). A java.io.InputStream is

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -9,7 +9,7 @@
   (:import java.io.ByteArrayOutputStream
            org.apache.jena.graph.NodeFactory
            org.apache.jena.query.QueryFactory
-           org.apache.jena.rdf.model.ModelFactory
+           [org.apache.jena.rdf.model ModelFactory Model]
            org.apache.jena.sparql.algebra.Algebra))
 
 (defn get-all-graphs []
@@ -94,7 +94,9 @@
     (.write model os "RDFTHRIFT")
     (.toByteArray os)))
 
-(defn union [& models]
+(defn union
+  "Create a new model that is the union of models"
+  [& models]
   (let [union-model (ModelFactory/createDefaultModel)]
     (doseq [model models] (.add union-model model))
     union-model))

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -90,7 +90,7 @@
   ;; This seems to break the contract for ILookup
   clojure.lang.ILookup
   (valAt [this k] (step k this model))
-  (valAt [this k nf] nf)
+  (valAt [this k nf] nf) ;; TODO fix this
 
 
   ;; Conforms to the expectations for a sequence representation of a map. Includes only

--- a/src/genegraph/env.clj
+++ b/src/genegraph/env.clj
@@ -12,7 +12,7 @@
 (def genegraph-bucket (System/getenv "GENEGRAPH_BUCKET"))
 (def use-gql-cache (System/getenv "GENEGRAPH_GQL_CACHE"))
 (def mode (System/getenv "GENEGRAPH_MODE"))
-(def validate-events (System/getenv "GENEGRAPH_VALIDATE_EVENTS"))
+(def validate-events (Boolean/valueOf (System/getenv "GENEGRAPH_VALIDATE_EVENTS")))
 (def use-response-cache (System/getenv "GENEGRAPH_RESPONSE_CACHE"))
 (def genegraph-version (System/getenv "GENEGRAPH_IMAGE_VERSION"))
 (def database-build-mode (System/getenv "GENEGRAPH_DATABASE_BUILD_MODE"))

--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -19,21 +19,6 @@
             [io.pedestal.log :as log]
             [clojure.spec.alpha :as spec]))
 
-
-(def write-tx-interceptor
-  {:name ::write-tx
-   :enter (fn [context]
-            (when-not (::dont-open-tx context)
-              (begin-write-tx))
-            context)
-   :leave (fn [context]
-            (when-not (::dont-open-tx context)
-              (if (or (:exception context)
-                      (::spec/invalid context))
-                (close-write-tx :abort)
-                (close-write-tx :commit)))
-            context)})
-
 (def context (atom {}))
 
 (defn add-to-db!
@@ -82,7 +67,7 @@
   {:name ::log-result
    :leave (fn [e] (log/debug
                    :fn :log-result-interceptor
-                   :event (select-keys e [::ann/iri ::ann/subjects :executed-interceptors])) e)})
+                   :event (select-keys e [::ann/iri ::ann/subjects ::ann/did-validate])) e)})
 
 (def abort-on-dry-run-interceptor
   {:name ::abort-on-dry-run
@@ -95,6 +80,7 @@
                         ann/add-metadata-interceptor
                         ann/add-model-interceptor
                         ann/add-iri-interceptor
+                        ann/add-validation-shape-interceptor
                         ann/add-validation-interceptor
                         ann/add-subjects-interceptor
                         ann/add-action-interceptor

--- a/src/genegraph/sink/event.clj
+++ b/src/genegraph/sink/event.clj
@@ -81,6 +81,7 @@
                         ann/add-model-interceptor
                         ann/add-iri-interceptor
                         ann/add-validation-shape-interceptor
+                        ann/add-validation-context-interceptor
                         ann/add-validation-interceptor
                         ann/add-subjects-interceptor
                         ann/add-action-interceptor

--- a/src/genegraph/transform/gene_validity_refactor.clj
+++ b/src/genegraph/transform/gene_validity_refactor.clj
@@ -1,0 +1,160 @@
+(ns genegraph.transform.gene-validity-refactor
+  (:require [genegraph.database.load :as l]
+            [genegraph.database.query :as q :refer [select construct ld-> ld1-> declare-query]]
+            [genegraph.transform.types :refer [transform-doc src-path add-model]]
+            [cheshire.core :as json]
+            [clojure.string :as s]
+            [clojure.java.io :as io :refer [resource]])
+  (:import java.io.ByteArrayInputStream ))
+
+(def base "http://dataexchange.clinicalgenome.org/gci/")
+
+(def gdm-sepio-relationships (l/read-rdf (str (resource "genegraph/transform/gene_validity_refactor/gdm_sepio_relationships.ttl")) {:format :turtle}))
+
+(def ns-prefixes {"dx" "http://dataexchange.clinicalgenome.org/"
+                  "sepio" "http://purl.obolibrary.org/obo/SEPIO_"
+                  "hp" "http://purl.obolibrary.org/obo/HP_"
+                  "dc" "http://purl.org/dc/terms/"
+                  "rdfs" "http://www.w3.org/2000/01/rdf-schema#"
+                  "dxgci" "http://dataexchange.clinicalgenome.org/gci/"
+                  "ro" "http://purl.obolibrary.org/obo/RO_"
+                  "mondo" "http://purl.obolibrary.org/obo/MONDO_"
+                  "car" "http://reg.genome.network/allele/"
+                  "cv" "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
+                  "hgnc" "https://identifiers.org/hgnc:"
+                  "pmid" "https://pubmed.ncbi.nlm.nih.gov/"})
+
+(declare-query construct-proposition
+               construct-evidence-level-assertion
+               ;; construct-proband-score
+               ;; construct-model-systems-evidence
+               ;; construct-functional-alteration-evidence
+               ;; construct-functional-evidence
+               ;; construct-rescue-evidence
+               ;; construct-case-control-evidence
+               ;; construct-segregation-evidence
+               construct-evidence-connections
+               )
+
+;; Trim trailing }, intended to be appended to gci json
+(def context
+  (s/join ""
+        (drop-last
+         (json/generate-string
+          {"@context" 
+           {
+            ;; frontmatter
+            "@version" "1.1"
+            "@vocab" "http://gci.clinicalgenome.org/"
+            "@base" "http://gci.clinicalgenome.org/"
+
+            "PK" "@id"
+            "item_type" "@type"
+
+            
+            ;; "gci" "http://gci.clinicalgenome.org/"
+            ;; "gcixform" "http://dataexchange.clinicalgenome.org/gcixform/"
+
+            ;; ;; common prefixes
+            "HGNC" "https://identifiers.org/hgnc:"
+            "MONDO" "http://purl.obolibrary.org/obo/MONDO_"
+            "SEPIO" "http://purl.obolibrary.org/obo/SEPIO_"
+            
+            ;; ;; declare attributes with @id, @vocab types
+            "hgncId" {"@type" "@id"}
+            "autoClassification" {"@type" "@vocab"}
+            ;; "diseaseId" {"@type" "@id"}
+            ;; "caseInfoType" {"@type" "@id"}
+            ;; "experimental_scored" {"@type" "@id"}
+            ;; "caseControl_scored" {"@type" "@id"}
+            ;; "variants" {"@type" "@id"}
+
+            ;; "modelSystemsType" {"@type" "@vocab"}
+            ;; "evidenceType" {"@type" "@vocab"}
+            ;; "functionalAlterationType" {"@type" "@vocab"}
+            ;; "rescueType" {"@type" "@vocab"}
+            ;; "studyType" {"@type" "@vocab"}
+            ;; "sequencingMethod" {"@type" "@vocab"}
+
+
+            ;; ;; Category names
+            ;; "Model Systems" "gcixform:ModelSystems"
+            ;; "Functional Alteration" "gcixform:FunctionalAlteration"
+            ;; "Case control" "gcixform:CaseControl"
+
+            ;; ;; Case control
+            ;; "Aggregate variant analysis" "gcixform:AggregateVariantAnalysis"
+            ;; "Single variant analysis" "gcixform:SingleVariantAnalysis"
+
+            ;; ;; segregation
+            ;; "Candidate gene sequencing" "gcixform:CandidateGeneSequencing"
+            ;; "Exome/genome or all genes sequenced in linkage region" "gcixform:ExomeSequencing"
+
+            ;; ;; Experimental evidence types
+            ;; "Expression" "gcixform:Expression"
+            ;; "Biochemical Function" "gcixform:BiochemicalFunction"
+            ;; "Protein Interactions" "gcixform:ProteinInteraction"
+
+            ;; ;; rescue
+            ;; "Cell culture" "gcixform:CellCulture"
+            ;; "Non-human model organism" "gcixform:NonHumanModel"
+            ;; "Patient cells" "gcixform:PatientCells"
+            ;; "Human" "gcixform:Human"
+
+            ;; ;; model systems
+            ;; "Cell culture model" "gcixform:CellCultureModel"
+
+            ;; ;; functional alteration
+            ;; "Non-patient cells" "gcixform:NonPatientCells"
+            ;; "patient cells" "gcixform:PatientCells"
+;; #{"Definitive" "Limited" "No Known Disease Relationship" "Moderate"
+;;   "No Classification" "Strong"}
+            ;; ;; evidence strength
+            "Definitive" "SEPIO:0004504"
+            "Strong" "SEPIO:0004505"
+            "Moderate" "SEPIO:0004506"
+            "Limited" "sepio:0004507"
+            "No Known Disease Relationship" "SEPIO:0004508"
+            "No Classification" "SEPIO:0004508" ;; Maybe this should not exist in published records?
+            ;; "No Classification" "SEPIO:0004508"
+            }}))))
+
+(defn parse-gdm [gdm-json]
+  (let [gdm-with-fixed-curies (s/replace gdm-json #"MONDO_" "MONDO:")
+        is (-> (str context "," (subs gdm-with-fixed-curies 1))
+               .getBytes
+               ByteArrayInputStream.)]
+    (l/read-rdf is {:format :json-ld})))
+
+(defn transform-gdm [gdm]
+  (.setNsPrefixes gdm ns-prefixes)
+  (let [params {::q/model (q/union gdm gdm-sepio-relationships)
+                :gcibase base
+                :arbase "http://reg.genome.network/allele/"
+                :cvbase "https://www.ncbi.nlm.nih.gov/clinvar/variation/"
+                :pmbase "https://pubmed.ncbi.nlm.nih.gov/"}
+        unlinked-model (q/union 
+                        (construct-proposition params)
+                        (construct-evidence-level-assertion params)
+                        ;; (construct-model-systems-evidence params)
+                        ;; (construct-functional-alteration-evidence params)
+                        ;; (construct-functional-evidence params)
+                        ;; (construct-proband-score params)
+                        ;; (construct-rescue-evidence params)
+                        ;; (construct-case-control-evidence params)
+                        ;; (construct-segregation-evidence params)
+                        )]
+    (q/union unlinked-model
+             (construct-evidence-connections 
+              {::q/model
+               (q/union unlinked-model
+                        gdm-sepio-relationships)}))))
+
+(defmethod add-model :gci-refactor
+  [event]
+  (assoc event
+         ::q/model
+         (-> event
+             :genegraph.sink.event/value
+             parse-gdm
+             transform-gdm)))

--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_connections.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_connections.sparql
@@ -1,0 +1,10 @@
+prefix gci: <http://gci.clinicalgenome.org/> 
+prefix gcixform: <http://dataexchange.clinicalgenome.org/gcixform/>
+construct {
+  ?criterionAssessment :sepio/has-evidence-line ?evidenceLine .
+}
+where {
+  ?criterionAssessment a ?criterionAssessmentType .
+  ?evidenceLine a ?evidenceLineType .
+  ?criterionAssessmentType gcixform:hasEvidenceLineType ?evidenceLineType .
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
@@ -1,0 +1,156 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+
+construct {
+  ?classification a :sepio/GeneValidityEvidenceLevelAssertion ;
+  :sepio/has-subject ?proposition ;
+  :sepio/has-predicate :sepio/HasEvidenceLevel ;
+  :sepio/has-object ?evidencelevel ;
+  # :sepio/has-evidence-line ?experimentalEvidenceLine, ?geneticEvidenceLine ;
+  # :sepio/evidence-line-strength-score ?evidencePointsTotal .
+
+  # ?geneticEvidenceLine a :sepio/GeneticEvidenceLine ;
+  # :sepio/has-evidence-item ?geneticEvidenceCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?geneticEvidenceTotal .
+
+  # ?geneticEvidenceCriterionAssessment a :sepio/GeneticEvidenceCriterionAssessment ;
+  # :sepio/has-evidence-line ?autosomalDominantOtherVariantEvidenceLine ,
+  # ?autosomalDominantNullVariantEvidenceLine ,
+  # ?autosomalDominantDeNovoVariantEvidenceLine , 
+  # ?autosomalRecessiveVariantEvidenceLine ,
+  # ?caseControlEvidenceLine ,
+  # ?segregationEvidenceLine .
+
+  # ?autosomalDominantOtherVariantEvidenceLine a :sepio/AutosomalDominantOtherVariantEvidenceLine ;
+  # :sepio/has-evidence-item ?autosomalDominantOtherVariantCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?probandWithOtherVariantTypeWithGeneImpactTotal .
+
+  # ?autosomalDominantOtherVariantCriterionAssessment a :sepio/AutosomalDominantOtherVariantCriterionAssessment .
+
+  # ?autosomalDominantNullVariantEvidenceLine a :sepio/AutosomalDominantNullVariantEvidenceLine ;
+  # :sepio/has-evidence-item ?autosomalDominantNullVariantCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?probandWithPredictedOrProvenNullVariantTotal .
+
+  # ?autosomalDominantNullVariantCriterionAssessment a :sepio/AutosomalDominantNullVariantCriterionAssessment .
+
+  # ?autosomalDominantDeNovoVariantEvidenceLine a :sepio/AutosomalDominantDeNovoVariantEvidenceLine ;
+  # :sepio/has-evidence-item ?autosomalDominantDeNovoVariantCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?variantIsDeNovoTotal .
+
+  # ?autosomalDominantDeNovoVariantCriterionAssessment a :sepio/AutosomalDominantDeNovoVariantCriterionAssessment .
+
+  # ?autosomalRecessiveVariantEvidenceLine a :sepio/AutosomalRecessiveVariantEvidenceLine ;
+  # :sepio/has-evidence-item ?autosomalRecessiveVariantCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?autosomalRecessiveDisorderTotal .
+
+  # ?autosomalRecessiveVariantCriterionAssessment a :sepio/AutosomalRecessiveVariantCriterionAssessment .
+
+  # ?caseControlEvidenceLine a :sepio/CaseControlEvidenceLine ;
+  # :sepio/has-evidence-item ?caseControlEvidenceCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?caseControlTotal .
+
+  # ?caseControlEvidenceCriterionAssessment a :sepio/CaseControlEvidenceCriterionAssessment .
+
+  # ?segregationEvidenceLine a :sepio/SegregationEvidenceLine ;
+  # :sepio/has-evidence-item ?segregationCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?segregationTotal .
+
+  # ?segregationCriterionAssessment a :sepio/SegregationCriterionAssessment .
+
+  # ?experimentalEvidenceLine a :sepio/ExperimentalEvidenceLine ;
+  # :sepio/has-evidence-item ?experimentalEvidenceCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?experimentalEvidenceTotal .
+
+  # ?experimentalEvidenceCriterionAssessment a :sepio/ExperimentalEvidenceCriterionAssessment ;
+  # :sepio/has-evidence-line ?functionalEvidenceLine, ?functionalAlterationEvidenceLine, ?modelAndRescueEvidenceLine .
+
+  # ?functionalEvidenceLine a :sepio/FunctionalEvidenceLine ;
+  # :sepio/has-evidence-item ?functionalCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?functionTotal .
+
+  # ?functionalCriterionAssessment a :sepio/FunctionalCriterionAssessment .
+
+  # ?functionalAlterationEvidenceLine a :sepio/FunctionalAlterationEvidenceLine ;
+  # :sepio/has-evidence-item ?functionalAlterationCriterionAssessment ;
+  # :sepio/evidence-line-strength-score ?functionalAlterationTotal .
+
+  # ?functionalAlterationCriterionAssessment a :sepio/FunctionalAlterationCriterionAssessment .  
+
+  # ?modelAndRescueEvidenceLine a :sepio/ModelAndRescueEvidenceLine ;
+  # :sepio/has-evidence-item ?modelAndRescueCriterionAssessment ;
+  # :sepio/evidence-line-strength-score  ?modelsRescueTotal .
+
+  # ?modelAndRescueCriterionAssessment a :sepio/ModelAndRescueCriterionAssessment .
+
+
+}
+where {
+  
+  ?classification a gci:provisionalClassification .
+  ?proposition a gci:gdm .
+  
+  ?classification gci:autoClassification ?evidencelevel .
+
+  # ?classification gci:classificationPoints ?pointsTree .
+  
+  # ?pointsTree gci:evidencePointsTotal ?evidencePointsTotal .
+  # ?pointsTree gci:experimentalEvidenceTotal ?experimentalEvidenceTotal .
+  # ?pointsTree gci:geneticEvidenceTotal ?geneticEvidenceTotal .
+
+  # ?pointsTree gci:autosomalDominantOrXlinkedDisorder ?autosomalDominantOrXlinkedDisorderTree .
+
+  # ?autosomalDominantOrXlinkedDisorderTree gci:probandWithOtherVariantTypeWithGeneImpact ?probandWithOtherVariantTypeWithGeneImpactTree .
+  # ?probandWithOtherVariantTypeWithGeneImpactTree gci:pointsCounted ?probandWithOtherVariantTypeWithGeneImpactTotal .
+
+  # ?autosomalDominantOrXlinkedDisorderTree gci:probandWithPredictedOrProvenNullVariant ?probandWithPredictedOrProvenNullVariantTree .
+  # ?probandWithPredictedOrProvenNullVariantTree gci:pointsCounted ?probandWithPredictedOrProvenNullVariantTotal .
+
+  # ?autosomalDominantOrXlinkedDisorderTree gci:variantIsDeNovo ?variantIsDeNovoTree .
+  # ?variantIsDeNovoTree gci:pointsCounted ?variantIsDeNovoTotal .
+
+  # ?pointsTree gci:autosomalRecessiveDisorder ?autosomalRecessiveDisorderTree .
+  # ?autosomalRecessiveDisorderTree gci:pointsCounted  ?autosomalRecessiveDisorderTotal .
+
+  # ?pointsTree gci:caseControl ?caseControlTree .
+  # ?caseControlTree gci:pointsCounted ?caseControlTotal .
+
+  # ?pointsTree gci:function ?functionTree .
+  # ?functionTree gci:pointsCounted ?functionTotal .
+
+  # ?pointsTree gci:functionalAlteration ?functionalAlterationTree .
+  # ?functionalAlterationTree gci:pointsCounted ?functionalAlterationTotal .
+
+  # ?pointsTree gci:modelsRescue ?modelsRescueTree .
+  # ?modelsRescueTree gci:pointsCounted ?modelsRescueTotal .
+
+  # ?pointsTree gci:segregation ?segregationTree .
+  # ?segregationTree gci:pointsCounted ?segregationTotal .
+
+  # BIND (IRI(CONCAT(?gcibase, "assertion_", ?classificationuuid)) AS ?assertion) .
+  # ?gdm a gci:gdm . 
+  # ?gdm gci:uuid ?gdmuuid . 
+  # BIND (IRI(CONCAT(?gcibase, "proposition_", ?gdmuuid)) AS ?prop) .
+
+  # BIND (IRI(CONCAT(?gcibase, "segregation_criterion_assessment", ?gdmuuid)) AS ?segregationCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "experimental_evidence_criterion_assessment", ?gdmuuid)) AS ?experimentalEvidenceCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_other_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantOtherVariantCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "genetic_evidence_criterion_assessment", ?gdmuuid)) AS ?geneticEvidenceCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_null_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantNullVariantCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_de_novo_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantDeNovoVariantCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_recessive_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalRecessiveVariantCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "model_and_rescue_criterion_assessment", ?gdmuuid)) AS ?modelAndRescueCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "case_control_evidence_criterion_assessment", ?gdmuuid)) AS ?caseControlEvidenceCriterionAssessment) .
+  # BIND (IRI(CONCAT(?gcibase, "functional_criterion_assessment", ?gdmuuid)) AS ?functionalCriterionAssessment) .
+
+  # BIND (IRI(CONCAT(?gcibase, "segregation_evidence_line", ?gdmuuid)) AS ?segregationEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_other_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantOtherVariantEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_de_novo_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantDeNovoVariantEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_null_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantNullVariantEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "autosomal_recessive_variant_evidence_line", ?gdmuuid)) AS ?autosomalRecessiveVariantEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "model_and_rescue_evidence_line", ?gdmuuid)) AS ?modelAndRescueEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "case_control_evidence_line", ?gdmuuid)) AS ?caseControlEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "functional_alteration_evidence_line", ?gdmuuid)) AS ?functionalAlterationEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "experimental_evidence_line", ?gdmuuid)) AS ?experimentalEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "functional_evidence_line", ?gdmuuid)) AS ?functionalEvidenceLine) .
+  # BIND (IRI(CONCAT(?gcibase, "genetic_evidence_line", ?gdmuuid)) AS ?geneticEvidenceLine) .
+
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_proposition.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_proposition.sparql
@@ -1,0 +1,20 @@
+prefix gci: <http://gci.clinicalgenome.org/> 
+construct 
+{
+  ?gdm a :sepio/GeneValidityProposition . 
+  ?gdm :sepio/has-subject ?hgnc .
+  ?gdm :sepio/has-predicate :ro/IsCausalGermlineMutationIn .
+  ?gdm :sepio/has-object ?disease .
+  ?gdm :sepio/has-qualifier ?moi .
+}
+where
+{
+  ?gdm a gci:gdm . 
+  ?gdm gci:gene ?gene .
+  ?gene gci:hgncId ?hgnc . 
+  ?gdm gci:disease ?disease .
+  ?gdm gci:modeInheritance ?moistr .
+
+  # The HPO term is embedded in a string, extract the digit and wrap in an IRI
+  BIND(IRI(CONCAT("http://purl.obolibrary.org/obo/HP_", REPLACE(?moistr, "[^0-9]", ""))) AS ?moi) .
+}

--- a/src/genegraph/transform/gene_validity_refactor/gdm_sepio_relationships.ttl
+++ b/src/genegraph/transform/gene_validity_refactor/gdm_sepio_relationships.ttl
@@ -1,0 +1,133 @@
+# This file maps terms used in the GCI GDM record to their related types in the sepio
+# model. It is intended to be merged into the GDM model and used as a source to derive
+# SEPIO types from information in the source model
+
+@prefix : <http://dataexchange.clinicalgenome.org/gcixform/> .
+@prefix gci:   <http://gci.clinicalgenome.org/> .
+@prefix sepio:   <http://purl.obolibrary.org/obo/SEPIO_> .
+@base <http://dataexchange.clinicalgenome.org/gcixform> .
+
+
+# Variant types
+gci:PREDICTED_OR_PROVEN_NULL_VARIANT :hasEvidenceLineType sepio:0004079 ;
+    :hasEvidenceItemType sepio:0004034 .
+    
+gci:VARIANT_IS_DE_NOVO :hasEvidenceLineType sepio:0004078 ;
+    :hasEvidenceItemType sepio:0004033 .
+    
+gci:OTHER_VARIANT_TYPE_WITH_GENE_IMPACT :hasEvidenceLineType sepio:0004080 ;
+    :hasEvidenceItemType sepio:0004035 .
+    
+gci:TWO_VARIANTS_WITH_GENE_IMPACT_IN_TRANS :hasEvidenceLineType sepio:0004019 ;
+    :hasEvidenceItemType sepio:0004037 .
+    
+gci:TWO_VARIANTS_IN_TRANS_WITH_ONE_DE_NOVO :hasEvidenceLineType sepio:0004018 ;
+    :hasEvidenceItemType sepio:0004038 .
+    
+
+# biochemical function
+sepio:0004022 :hasEvidenceItemType sepio:0004041 ;
+    :hasGCIType :BiochemicalFunction ;
+    :usedIn :Functional .
+    
+# protein interaction
+sepio:0004023 :hasEvidenceItemType sepio:0004042 ;
+    :hasGCIType :ProteinInteraction ;
+    :usedIn :Functional .
+    
+# gene expression
+sepio:0004024 :hasEvidenceItemType sepio:0004043 ;
+    :hasGCIType :Expression ;
+    :usedIn :Functional .
+
+# patient cell functional alteration
+sepio:0004025 :hasEvidenceItemType sepio:0004044 ;
+    :hasGCIType :PatientCells ;
+    :usedIn :FunctionalAlteration .
+
+# non-patient cell functional alteration
+sepio:0004026 :hasEvidenceItemType sepio:0004045 ;
+    :hasGCIType :NonPatientCells ;
+    :usedIn :FunctionalAlteration .
+    
+# non-human model
+sepio:0004027 :hasEvidenceItemType sepio:0004046 ;
+    :hasGCIType :NonHumanModel ;
+    :usedIn :ModelSystems .
+    
+# cell culture model
+sepio:0004028 :hasEvidenceItemType sepio:0004047 ;
+    :hasGCIType :CellCultureModel ;
+    :usedIn :ModelSystems .
+    
+# human rescue
+sepio:0004029 :hasEvidenceItemType sepio:0004048 ;
+    :hasGCIType :Human ;
+    :usedIn :Rescue .
+    
+# non-human model rescue
+sepio:0004030 :hasEvidenceItemType sepio:0004049 ;
+    :hasGCIType :NonHumanModel ;
+    :usedIn :Rescue .
+    
+# rescue in cell culture
+sepio:0004031 :hasEvidenceItemType sepio:0004050 ;
+    :hasGCIType :CellCulture ;
+    :usedIn :Rescue .
+    
+# rescue in patient cells
+sepio:0004032 :hasEvidenceItemType sepio:0004051 ;
+    :hasGCIType :PatientCells ;
+    :usedIn :Rescue .
+
+#### Case Control
+sepio:0004020 :hasEvidenceItemType sepio:0004039 ;
+    :hasGCIType :SingleVariantAnalysis .
+    
+sepio:0004021 :hasEvidenceItemType sepio:0004040 ;
+    :hasGCIType :AggregateVariantAnalysis .
+
+#### Segregation
+
+# single gene
+sepio:0004090 :hasEvidenceItemType sepio:0004085 ;
+    :hasGCIType :CandidateGeneSequencing .
+
+# multi-locus
+sepio:0004091 :hasEvidenceItemType sepio:0004086 ;
+    :hasGCIType :ExomeSequencing .
+    
+#### Connections to leaf-node evidence lines
+
+# :sepio/AutosomalDominantOtherVariantCriterionAssessment
+sepio:0004058 :hasEvidenceLineType sepio:0004080 .
+
+# :sepio/AutosomalDominantNullVariantCriterionAssessment
+sepio:0004057 :hasEvidenceLineType sepio:0004079 .
+
+# :sepio/AutosomalDominantDeNovoVariantCriterionAssessment
+sepio:0004056 :hasEvidenceLineType sepio:0004078 .
+
+# :sepio/AutosomalRecessiveVariantCriterionAssessment
+sepio:0004055 :hasEvidenceLineType sepio:0004019 , sepio:0004018 .
+
+# # :sepio/CaseControlEvidenceCriterionAssessment
+sepio:0004054 :hasEvidenceLineType sepio:0004020, sepio:0004021 .
+
+# # :sepio/SegregationCriterionAssessment
+sepio:0004059 :hasEvidenceLineType sepio:0004090, sepio:0004091 .
+
+# :sepio/FunctionalCriterionAssessment
+sepio:0004060 :hasEvidenceLineType sepio:0004022 , sepio:0004023 , sepio:0004024 .
+
+# :sepio/FunctionalAlterationCriterionAssessment
+sepio:0004061 :hasEvidenceLineType sepio:0004025 , sepio:0004026 .
+
+# :sepio/ModelAndRescueCriterionAssessment
+sepio:0004062 :hasEvidenceLineType sepio:0004027 ,
+        sepio:0004028 , 
+        sepio:0004029 , 
+        sepio:0004030 , 
+        sepio:0004031 , 
+        sepio:0004032 .
+    

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -12,6 +12,8 @@
             [genegraph.rocksdb :as rocks]
             [genegraph.migration :as migrate]
             [genegraph.sink.rocksdb :as rocks-sink]
+            [genegraph.transform.gene-validity :as gene-validity]
+            [genegraph.transform.gene-validity-refactor :as gene-validity-refactor]
             [cheshire.core :as json]
             [clojure.data.csv :as csv]
             [clojure.string :as s]
@@ -59,6 +61,15 @@
   [event-seq]
   (doseq [event event-seq]
     (event/process-event! (assoc event ::event/dry-run true))))
+
+(defn update-topic-db
+  "Run topic db through dry-run event processor, store result in db"
+  [event-db]
+  (doseq [event (pmap
+                 process-event-dry-run
+                 (rocks/entire-db-seq event-db))]
+    (rocks-sink/put! event-db event)))
+
 
 (defn get-graph-names []
   (tx


### PR DESCRIPTION
Work on the data migration for the GCI full dataset continues, but this feels like a good checkpoint for a PR, not least because there's a little refactor of the SHACL validation included. This refactor accomplishes a couple of things: validation was a little broken to begin with, this fixes it, also this allows one to pass a shape into the event chain as an option, making it easier to develop a SHACL shape relative to an input sequence. Some functions have been added to the util.repl namespace to support this kind of development. Additionally, support for a 'validation context' has been added, a model to which one can add the input model for validation purposes. This means it's possible to add the SEPIO value sets and whatnot to ensure that the input model matches the expected terms.