### PR TITLE
Disable tracing in prod

### DIFF
--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -65,6 +65,7 @@
   (let [interceptor-chain
         (-> (lacinia-pedestal/default-interceptors (gql/schema) {})
             (lacinia/inject nil :replace ::lacinia-pedestal/body-data)
+            (lacinia/inject nil :replace ::lacinia-pedestal/enable-tracing)
             (lacinia/inject lacinia-pedestal/body-data-interceptor
                             :before
                             ::lacinia-pedestal/json-response)
@@ -102,6 +103,7 @@
 (defn prod-subscription-interceptors []
   (let [interceptor-chain 
         (-> (lacinia-subs/default-subscription-interceptors (gql/schema) {})
+            (lacinia/inject nil :replace ::lacinia-pedestal/enable-tracing)
             (lacinia/inject (pedestal-interceptor/interceptor open-tx-interceptor)
                             :before
                             ::lacinia-subs/execute-operation)

--- a/src/genegraph/transform/gene_validity_refactor.clj
+++ b/src/genegraph/transform/gene_validity_refactor.clj
@@ -26,6 +26,11 @@
 
 (declare-query construct-proposition
                construct-evidence-level-assertion
+               construct-experimental-evidence-assertions
+               construct-genetic-evidence-assertion
+               construct-ad-variant-assertions
+               construct-ar-variant-assertions
+               construct-cc-and-seg-assertions
                ;; construct-proband-score
                ;; construct-model-systems-evidence
                ;; construct-functional-alteration-evidence
@@ -136,6 +141,11 @@
         unlinked-model (q/union 
                         (construct-proposition params)
                         (construct-evidence-level-assertion params)
+                        (construct-experimental-evidence-assertions params)
+                        (construct-genetic-evidence-assertion params)
+                        (construct-ad-variant-assertions params)
+                        (construct-ar-variant-assertions params)
+                        (construct-cc-and-seg-assertions params)
                         ;; (construct-model-systems-evidence params)
                         ;; (construct-functional-alteration-evidence params)
                         ;; (construct-functional-evidence params)

--- a/src/genegraph/transform/gene_validity_refactor/construct_ad_variant_assertions.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_ad_variant_assertions.sparql
@@ -1,0 +1,50 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+
+construct
+{
+  ?geneticEvidenceCriterionAssessment :sepio/has-evidence-line ?autosomalDominantOtherVariantEvidenceLine ,   ?autosomalDominantNullVariantEvidenceLine ,  ?autosomalDominantDeNovoVariantEvidenceLine .
+  
+  ?autosomalDominantOtherVariantEvidenceLine a :sepio/AutosomalDominantOtherVariantEvidenceLine ;
+  :sepio/has-evidence-item ?autosomalDominantOtherVariantCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?probandWithOtherVariantTypeWithGeneImpactTotal .
+
+  ?autosomalDominantOtherVariantCriterionAssessment a :sepio/AutosomalDominantOtherVariantCriterionAssessment .
+
+  ?autosomalDominantNullVariantEvidenceLine a :sepio/AutosomalDominantNullVariantEvidenceLine ;
+  :sepio/has-evidence-item ?autosomalDominantNullVariantCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?probandWithPredictedOrProvenNullVariantTotal .
+
+  ?autosomalDominantNullVariantCriterionAssessment a :sepio/AutosomalDominantNullVariantCriterionAssessment .
+
+  ?autosomalDominantDeNovoVariantEvidenceLine a :sepio/AutosomalDominantDeNovoVariantEvidenceLine ;
+  :sepio/has-evidence-item ?autosomalDominantDeNovoVariantCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?variantIsDeNovoTotal .
+
+  ?autosomalDominantDeNovoVariantCriterionAssessment a :sepio/AutosomalDominantDeNovoVariantCriterionAssessment .
+}
+where
+{
+  ?classification a gci:provisionalClassification .
+  ?classification gci:classificationPoints ?pointsTree .
+
+  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_criterion_assessment")) AS ?geneticEvidenceCriterionAssessment) .
+  
+  ?pointsTree gci:autosomalDominantOrXlinkedDisorder ?autosomalDominantOrXlinkedDisorderTree .
+
+  ?autosomalDominantOrXlinkedDisorderTree gci:probandWithOtherVariantTypeWithGeneImpact ?probandWithOtherVariantTypeWithGeneImpactTree .
+  ?probandWithOtherVariantTypeWithGeneImpactTree gci:pointsCounted ?probandWithOtherVariantTypeWithGeneImpactTotal .
+
+  ?autosomalDominantOrXlinkedDisorderTree gci:probandWithPredictedOrProvenNullVariant ?probandWithPredictedOrProvenNullVariantTree .
+  ?probandWithPredictedOrProvenNullVariantTree gci:pointsCounted ?probandWithPredictedOrProvenNullVariantTotal .
+
+  ?autosomalDominantOrXlinkedDisorderTree gci:variantIsDeNovo ?variantIsDeNovoTree .
+  ?variantIsDeNovoTree gci:pointsCounted ?variantIsDeNovoTotal .
+
+  BIND(IRI(CONCAT(str(?classification), "_ad_other_el")) AS ?autosomalDominantOtherVariantEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_ad_other_ca")) AS ?autosomalDominantOtherVariantCriterionAssessment) .
+  BIND(IRI(CONCAT(str(?classification), "_ad_null_el")) AS ?autosomalDominantNullVariantEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_ad_null_ca")) AS ?autosomalDominantNullVariantCriterionAssessment) .
+  BIND(IRI(CONCAT(str(?classification), "_ad_dn_el")) AS ?autosomalDominantDeNovoVariantEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_ad_dn_ca")) AS ?autosomalDominantDeNovoVariantCriterionAssessment) .
+  
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_assertions.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_assertions.sparql
@@ -1,0 +1,25 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+construct
+{
+  ?geneticEvidenceCriterionAssessment :sepio/has-evidence-line ?autosomalRecessiveVariantEvidenceLine .
+  
+  ?autosomalRecessiveVariantEvidenceLine a :sepio/AutosomalRecessiveVariantEvidenceLine ;
+  :sepio/has-evidence-item ?autosomalRecessiveVariantCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?autosomalRecessiveDisorderTotal .  
+
+  ?autosomalRecessiveVariantCriterionAssessment a :sepio/AutosomalRecessiveVariantCriterionAssessment .
+}
+where
+{
+  ?classification a gci:provisionalClassification .
+
+  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_criterion_assessment")) AS ?geneticEvidenceCriterionAssessment) .
+
+  ?classification gci:classificationPoints ?pointsTree .
+
+  ?pointsTree gci:autosomalRecessiveDisorder ?autosomalRecessiveDisorderTree .
+  ?autosomalRecessiveDisorderTree gci:pointsCounted  ?autosomalRecessiveDisorderTotal .
+
+  BIND (IRI(CONCAT(str(?classification), "_ar_ca")) AS ?autosomalRecessiveVariantCriterionAssessment) .
+  BIND (IRI(CONCAT(str(?classification), "_ar_el")) AS ?autosomalRecessiveVariantEvidenceLine ) .
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_cc_and_seg_assertions.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_cc_and_seg_assertions.sparql
@@ -1,0 +1,39 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+
+construct
+{
+  ?geneticEvidenceCriterionAssessment :sepio/has-evidence-line ?caseControlEvidenceLine , ?segregationEvidenceLine .
+
+  ?caseControlEvidenceLine a :sepio/CaseControlEvidenceLine ;
+  :sepio/has-evidence-item ?caseControlEvidenceCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?caseControlTotal .
+
+  ?caseControlEvidenceCriterionAssessment a :sepio/CaseControlEvidenceCriterionAssessment .
+
+  ?segregationEvidenceLine a :sepio/SegregationEvidenceLine ;
+  :sepio/has-evidence-item ?segregationCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?segregationTotal .
+
+  ?segregationCriterionAssessment a :sepio/SegregationCriterionAssessment .
+  
+}
+where
+{
+
+  ?classification a gci:provisionalClassification .
+
+  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_criterion_assessment")) AS ?geneticEvidenceCriterionAssessment) .
+  
+  ?classification gci:classificationPoints ?pointsTree .
+
+  ?pointsTree gci:segregation ?segregationTree .
+  ?segregationTree gci:pointsCounted ?segregationTotal .
+
+  ?pointsTree gci:caseControl ?caseControlTree .
+  ?caseControlTree gci:pointsCounted ?caseControlTotal .
+
+  BIND (IRI(CONCAT(str(?classification), "_cc_el")) AS ?caseControlEvidenceLine) .
+  BIND (IRI(CONCAT(str(?classification), "_cc_ca")) AS ?caseControlEvidenceCriterionAssessment) .
+  BIND (IRI(CONCAT(str(?classification), "_seg_el")) AS ?segregationEvidenceLine) .
+  BIND (IRI(CONCAT(str(?classification), "_seg_ca")) AS ?segregationCriterionAssessment) .  
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
@@ -1,156 +1,24 @@
 prefix gci: <http://gci.clinicalgenome.org/>
 
 construct {
+  
   ?classification a :sepio/GeneValidityEvidenceLevelAssertion ;
   :sepio/has-subject ?proposition ;
   :sepio/has-predicate :sepio/HasEvidenceLevel ;
   :sepio/has-object ?evidencelevel ;
-  # :sepio/has-evidence-line ?experimentalEvidenceLine, ?geneticEvidenceLine ;
-  # :sepio/evidence-line-strength-score ?evidencePointsTotal .
-
-  # ?geneticEvidenceLine a :sepio/GeneticEvidenceLine ;
-  # :sepio/has-evidence-item ?geneticEvidenceCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?geneticEvidenceTotal .
-
-  # ?geneticEvidenceCriterionAssessment a :sepio/GeneticEvidenceCriterionAssessment ;
-  # :sepio/has-evidence-line ?autosomalDominantOtherVariantEvidenceLine ,
-  # ?autosomalDominantNullVariantEvidenceLine ,
-  # ?autosomalDominantDeNovoVariantEvidenceLine , 
-  # ?autosomalRecessiveVariantEvidenceLine ,
-  # ?caseControlEvidenceLine ,
-  # ?segregationEvidenceLine .
-
-  # ?autosomalDominantOtherVariantEvidenceLine a :sepio/AutosomalDominantOtherVariantEvidenceLine ;
-  # :sepio/has-evidence-item ?autosomalDominantOtherVariantCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?probandWithOtherVariantTypeWithGeneImpactTotal .
-
-  # ?autosomalDominantOtherVariantCriterionAssessment a :sepio/AutosomalDominantOtherVariantCriterionAssessment .
-
-  # ?autosomalDominantNullVariantEvidenceLine a :sepio/AutosomalDominantNullVariantEvidenceLine ;
-  # :sepio/has-evidence-item ?autosomalDominantNullVariantCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?probandWithPredictedOrProvenNullVariantTotal .
-
-  # ?autosomalDominantNullVariantCriterionAssessment a :sepio/AutosomalDominantNullVariantCriterionAssessment .
-
-  # ?autosomalDominantDeNovoVariantEvidenceLine a :sepio/AutosomalDominantDeNovoVariantEvidenceLine ;
-  # :sepio/has-evidence-item ?autosomalDominantDeNovoVariantCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?variantIsDeNovoTotal .
-
-  # ?autosomalDominantDeNovoVariantCriterionAssessment a :sepio/AutosomalDominantDeNovoVariantCriterionAssessment .
-
-  # ?autosomalRecessiveVariantEvidenceLine a :sepio/AutosomalRecessiveVariantEvidenceLine ;
-  # :sepio/has-evidence-item ?autosomalRecessiveVariantCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?autosomalRecessiveDisorderTotal .
-
-  # ?autosomalRecessiveVariantCriterionAssessment a :sepio/AutosomalRecessiveVariantCriterionAssessment .
-
-  # ?caseControlEvidenceLine a :sepio/CaseControlEvidenceLine ;
-  # :sepio/has-evidence-item ?caseControlEvidenceCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?caseControlTotal .
-
-  # ?caseControlEvidenceCriterionAssessment a :sepio/CaseControlEvidenceCriterionAssessment .
-
-  # ?segregationEvidenceLine a :sepio/SegregationEvidenceLine ;
-  # :sepio/has-evidence-item ?segregationCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?segregationTotal .
-
-  # ?segregationCriterionAssessment a :sepio/SegregationCriterionAssessment .
-
-  # ?experimentalEvidenceLine a :sepio/ExperimentalEvidenceLine ;
-  # :sepio/has-evidence-item ?experimentalEvidenceCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?experimentalEvidenceTotal .
-
-  # ?experimentalEvidenceCriterionAssessment a :sepio/ExperimentalEvidenceCriterionAssessment ;
-  # :sepio/has-evidence-line ?functionalEvidenceLine, ?functionalAlterationEvidenceLine, ?modelAndRescueEvidenceLine .
-
-  # ?functionalEvidenceLine a :sepio/FunctionalEvidenceLine ;
-  # :sepio/has-evidence-item ?functionalCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?functionTotal .
-
-  # ?functionalCriterionAssessment a :sepio/FunctionalCriterionAssessment .
-
-  # ?functionalAlterationEvidenceLine a :sepio/FunctionalAlterationEvidenceLine ;
-  # :sepio/has-evidence-item ?functionalAlterationCriterionAssessment ;
-  # :sepio/evidence-line-strength-score ?functionalAlterationTotal .
-
-  # ?functionalAlterationCriterionAssessment a :sepio/FunctionalAlterationCriterionAssessment .  
-
-  # ?modelAndRescueEvidenceLine a :sepio/ModelAndRescueEvidenceLine ;
-  # :sepio/has-evidence-item ?modelAndRescueCriterionAssessment ;
-  # :sepio/evidence-line-strength-score  ?modelsRescueTotal .
-
-  # ?modelAndRescueCriterionAssessment a :sepio/ModelAndRescueCriterionAssessment .
-
+  :sepio/has-evidence-line ?experimentalEvidenceLine, ?geneticEvidenceLine ;
+  :sepio/evidence-line-strength-score ?evidencePointsTotal .
 
 }
 where {
-  
+
   ?classification a gci:provisionalClassification .
   ?proposition a gci:gdm .
   
   ?classification gci:autoClassification ?evidencelevel .
 
-  # ?classification gci:classificationPoints ?pointsTree .
+  ?classification gci:classificationPoints ?pointsTree .
   
-  # ?pointsTree gci:evidencePointsTotal ?evidencePointsTotal .
-  # ?pointsTree gci:experimentalEvidenceTotal ?experimentalEvidenceTotal .
-  # ?pointsTree gci:geneticEvidenceTotal ?geneticEvidenceTotal .
-
-  # ?pointsTree gci:autosomalDominantOrXlinkedDisorder ?autosomalDominantOrXlinkedDisorderTree .
-
-  # ?autosomalDominantOrXlinkedDisorderTree gci:probandWithOtherVariantTypeWithGeneImpact ?probandWithOtherVariantTypeWithGeneImpactTree .
-  # ?probandWithOtherVariantTypeWithGeneImpactTree gci:pointsCounted ?probandWithOtherVariantTypeWithGeneImpactTotal .
-
-  # ?autosomalDominantOrXlinkedDisorderTree gci:probandWithPredictedOrProvenNullVariant ?probandWithPredictedOrProvenNullVariantTree .
-  # ?probandWithPredictedOrProvenNullVariantTree gci:pointsCounted ?probandWithPredictedOrProvenNullVariantTotal .
-
-  # ?autosomalDominantOrXlinkedDisorderTree gci:variantIsDeNovo ?variantIsDeNovoTree .
-  # ?variantIsDeNovoTree gci:pointsCounted ?variantIsDeNovoTotal .
-
-  # ?pointsTree gci:autosomalRecessiveDisorder ?autosomalRecessiveDisorderTree .
-  # ?autosomalRecessiveDisorderTree gci:pointsCounted  ?autosomalRecessiveDisorderTotal .
-
-  # ?pointsTree gci:caseControl ?caseControlTree .
-  # ?caseControlTree gci:pointsCounted ?caseControlTotal .
-
-  # ?pointsTree gci:function ?functionTree .
-  # ?functionTree gci:pointsCounted ?functionTotal .
-
-  # ?pointsTree gci:functionalAlteration ?functionalAlterationTree .
-  # ?functionalAlterationTree gci:pointsCounted ?functionalAlterationTotal .
-
-  # ?pointsTree gci:modelsRescue ?modelsRescueTree .
-  # ?modelsRescueTree gci:pointsCounted ?modelsRescueTotal .
-
-  # ?pointsTree gci:segregation ?segregationTree .
-  # ?segregationTree gci:pointsCounted ?segregationTotal .
-
-  # BIND (IRI(CONCAT(?gcibase, "assertion_", ?classificationuuid)) AS ?assertion) .
-  # ?gdm a gci:gdm . 
-  # ?gdm gci:uuid ?gdmuuid . 
-  # BIND (IRI(CONCAT(?gcibase, "proposition_", ?gdmuuid)) AS ?prop) .
-
-  # BIND (IRI(CONCAT(?gcibase, "segregation_criterion_assessment", ?gdmuuid)) AS ?segregationCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "experimental_evidence_criterion_assessment", ?gdmuuid)) AS ?experimentalEvidenceCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_other_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantOtherVariantCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "genetic_evidence_criterion_assessment", ?gdmuuid)) AS ?geneticEvidenceCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_null_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantNullVariantCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_de_novo_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalDominantDeNovoVariantCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_recessive_variant_criterion_assessment", ?gdmuuid)) AS ?autosomalRecessiveVariantCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "model_and_rescue_criterion_assessment", ?gdmuuid)) AS ?modelAndRescueCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "case_control_evidence_criterion_assessment", ?gdmuuid)) AS ?caseControlEvidenceCriterionAssessment) .
-  # BIND (IRI(CONCAT(?gcibase, "functional_criterion_assessment", ?gdmuuid)) AS ?functionalCriterionAssessment) .
-
-  # BIND (IRI(CONCAT(?gcibase, "segregation_evidence_line", ?gdmuuid)) AS ?segregationEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_other_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantOtherVariantEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_de_novo_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantDeNovoVariantEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_dominant_null_variant_evidence_line", ?gdmuuid)) AS ?autosomalDominantNullVariantEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "autosomal_recessive_variant_evidence_line", ?gdmuuid)) AS ?autosomalRecessiveVariantEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "model_and_rescue_evidence_line", ?gdmuuid)) AS ?modelAndRescueEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "case_control_evidence_line", ?gdmuuid)) AS ?caseControlEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "functional_alteration_evidence_line", ?gdmuuid)) AS ?functionalAlterationEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "experimental_evidence_line", ?gdmuuid)) AS ?experimentalEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "functional_evidence_line", ?gdmuuid)) AS ?functionalEvidenceLine) .
-  # BIND (IRI(CONCAT(?gcibase, "genetic_evidence_line", ?gdmuuid)) AS ?geneticEvidenceLine) .
-
+  ?pointsTree gci:evidencePointsTotal ?evidencePointsTotal .
+  
 }

--- a/src/genegraph/transform/gene_validity_refactor/construct_experimental_evidence_assertions.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_experimental_evidence_assertions.sparql
@@ -1,0 +1,70 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+
+construct
+{
+  ?classification :sepio/has-evidence-line ?experimentalEvidenceLine .
+  
+  ?experimentalEvidenceLine a :sepio/ExperimentalEvidenceLine ;
+  :sepio/has-evidence-item ?experimentalEvidenceCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?experimentalEvidenceTotal .
+
+  ?experimentalEvidenceCriterionAssessment a :sepio/ExperimentalEvidenceCriterionAssessment ;
+  :sepio/has-evidence-line ?functionalEvidenceLine, ?functionalAlterationEvidenceLine, ?modelAndRescueEvidenceLine .
+
+  ?functionalEvidenceLine a :sepio/FunctionalEvidenceLine ;
+  :sepio/has-evidence-item ?functionalCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?functionTotal .
+
+  ?functionalCriterionAssessment a :sepio/FunctionalCriterionAssessment .
+
+  ?functionalAlterationEvidenceLine a :sepio/FunctionalAlterationEvidenceLine ;
+  :sepio/has-evidence-item ?functionalAlterationCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?functionalAlterationTotal .
+
+  ?functionalAlterationCriterionAssessment a :sepio/FunctionalAlterationCriterionAssessment .  
+
+  ?modelAndRescueEvidenceLine a :sepio/ModelAndRescueEvidenceLine ;
+  :sepio/has-evidence-item ?modelAndRescueCriterionAssessment ;
+  :sepio/evidence-line-strength-score  ?modelsRescueTotal .
+
+  ?modelAndRescueCriterionAssessment a :sepio/ModelAndRescueCriterionAssessment .
+}
+where
+{
+  #### Bind evidence points
+  
+  ?classification a gci:provisionalClassification .
+  ?classification gci:classificationPoints ?pointsTree .
+
+  ?pointsTree gci:experimentalEvidenceTotal ?experimentalEvidenceTotal .
+
+  ?pointsTree gci:function ?functionTree .
+  ?functionTree gci:pointsCounted ?functionTotal .
+
+  ?pointsTree gci:functionalAlteration ?functionalAlterationTree .
+  ?functionalAlterationTree gci:pointsCounted ?functionalAlterationTotal .
+
+  ?pointsTree gci:modelsRescue ?modelsRescueTree .
+  ?modelsRescueTree gci:pointsCounted ?modelsRescueTotal .
+
+  ?pointsTree gci:segregation ?segregationTree .
+  ?segregationTree gci:pointsCounted ?segregationTotal .
+
+  #### Bind criterion assessment and evidence line identifiers
+  BIND(IRI(CONCAT(str(?classification), "_experimental_evidence_line"))
+       AS ?experimentalEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_experimental_evidence_criterion_assessment"))
+       AS ?experimentalEvidenceCriterionAssessment) .
+  BIND(IRI(CONCAT(str(?classification), "_functional_evidence_line"))
+       AS ?functionalEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_functional_evidence_criterion_assessment"))
+       AS ?functionalEvidenceCriterionAssessment) .
+  BIND(IRI(CONCAT(str(?classification), "_functional_alteration_evidence_line"))
+       AS ?functionalAlterationEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_functional_alteration_criterion_assessment"))
+       AS ?functionalAlterationCriterionAssessment) .
+  BIND(IRI(CONCAT(str(?classification), "_model_rescue_evidence_line"))
+       AS ?modelAndRescueEvidenceLine) .
+  BIND(IRI(CONCAT(str(?classification), "_model_rescue_criterion_assessment"))
+       AS ?modelAndRescueCriterionAssessment) .
+}

--- a/src/genegraph/transform/gene_validity_refactor/construct_genetic_evidence_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_genetic_evidence_assertion.sparql
@@ -1,0 +1,21 @@
+prefix gci: <http://gci.clinicalgenome.org/>
+construct
+{
+  ?classification :sepio/has-evidence-line ?geneticEvidenceLine .
+  
+  ?geneticEvidenceLine a :sepio/GeneticEvidenceLine ;
+  :sepio/has-evidence-item ?geneticEvidenceCriterionAssessment ;
+  :sepio/evidence-line-strength-score ?geneticEvidenceTotal .
+
+  ?geneticEvidenceCriterionAssessment a :sepio/GeneticEvidenceCriterionAssessment ;
+}
+where
+{
+  ?classification a gci:provisionalClassification .
+  ?classification gci:classificationPoints ?pointsTree .
+
+  ?pointsTree gci:geneticEvidenceTotal ?geneticEvidenceTotal .
+
+  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_criterion_assessment")) AS ?geneticEvidenceCriterionAssessment) .
+  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_line")) AS ?geneticEvidenceLine) .
+}

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -73,6 +73,10 @@
        (filter #(= false (::ann/did-validate %)))
        first))
 
+(defn print-model
+  [event]
+  (println (some-> event ::q/model q/to-turtle)))
+
 (defn process-event-seq-dry-run
   "Run event sequence through event processor; do not perform side effects"
   [event-seq]


### PR DESCRIPTION
This one is important--the update to lacinia-pedestal came with tracing enabled by default.  It's a neat feature for evaluating the performance of interceptors, but kinda bloats the payload and process time for an actual request. This should be disabled in production.

Would not deploy an update to production without accepting this PR first.