### PR TITLE
Fixing dosage jira bug for triplo refuting assertions

### DIFF
--- a/resources/class-names.edn
+++ b/resources/class-names.edn
@@ -107,6 +107,7 @@
  [:sepio/DosageMinimalEvidence "http://purl.obolibrary.org/obo/SEPIO_0002007"]
  [:sepio/DosageModerateEvidence "http://purl.obolibrary.org/obo/SEPIO_0002009"]
  [:sepio/DosageSufficientEvidence "http://purl.obolibrary.org/obo/SEPIO_0002006"]
+ [:sepio/DosageRefutingEvidence "http://purl.obolibrary.org/obo/SEPIO_0002507"]
  [:sepio/DosageScopeAssertion "http://purl.obolibrary.org/obo/SEPIO_0002505"]
  [:sepio/GeneAssociatedWithAutosomalRecessivePhenotype "http://purl.obolibrary.org/obo/SEPIO_0002502"]
  [:sepio/HasEvidenceLevel "http://purl.obolibrary.org/obo/SEPIO_0000146"]

--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -103,7 +103,6 @@
 (defn prod-subscription-interceptors []
   (let [interceptor-chain 
         (-> (lacinia-subs/default-subscription-interceptors (gql/schema) {})
-            (lacinia/inject nil :replace ::lacinia-pedestal/enable-tracing)
             (lacinia/inject (pedestal-interceptor/interceptor open-tx-interceptor)
                             :before
                             ::lacinia-subs/execute-operation)

--- a/src/genegraph/source/graphql/dosage_proposition.clj
+++ b/src/genegraph/source/graphql/dosage_proposition.clj
@@ -1,7 +1,8 @@
 (ns genegraph.source.graphql.dosage-proposition
   (:require [genegraph.database.query :as q]
             [genegraph.source.graphql.common.cache :refer [defresolver]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [io.pedestal.log :as log]))
 
 (defresolver wg-label [args value]
   "Gene Dosage Working Group")

--- a/src/genegraph/transform/dosage_jira.clj
+++ b/src/genegraph/transform/dosage_jira.clj
@@ -214,11 +214,12 @@
    [iri :geno/has-location (subject-iri curation)]])
 
 (defn- proposition-predicate [curation dosage]
-  (if (and (= 1 dosage)
-           (= "40: Dosage sensitivity unlikely" 
-              (get-in curation [:fields :customfield-10165 :value])))
-    :geno/BenignForCondition
-    :geno/PathogenicForCondition))
+  (let [dosage-assertion-str (if (= 1 dosage)
+                               (get-in curation [:fields :customfield-10165 :value])
+                               (get-in curation [:fields :customfield-10166 :value]))]
+    (if (= "40: Dosage sensitivity unlikely" dosage-assertion-str)
+      :geno/BenignForCondition
+      :geno/PathogenicForCondition)))
 
 (defn- proposition [curation dosage]
   (let [iri (proposition-iri curation dosage)


### PR DESCRIPTION
Fixes dosage bug regarding triplo assertions that have dosage sensitivity unlikely assertions.