### PR TITLE
Request gating

### DIFF
--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -132,6 +132,9 @@
 
 (defn dev-subscription-interceptors [gql-schema]
   (-> (lacinia-subs/default-subscription-interceptors gql-schema {})
+      (lacinia/inject request-gate-interceptor
+                      :before
+                      ::lacinia-subs/execute-operation)
       (lacinia/inject (pedestal-interceptor/interceptor open-tx-interceptor)
                       :before
                       ::lacinia-subs/execute-operation)
@@ -148,6 +151,9 @@
 (defn prod-subscription-interceptors [gql-schema]
   (let [interceptor-chain 
         (-> (lacinia-subs/default-subscription-interceptors gql-schema {})
+            (lacinia/inject request-gate-interceptor
+                            :before
+                            ::lacinia-subs/execute-operation)
             (lacinia/inject (pedestal-interceptor/interceptor open-tx-interceptor)
                             :before
                             ::lacinia-subs/execute-operation)

--- a/test/genegraph/service_test.clj
+++ b/test/genegraph/service_test.clj
@@ -1,6 +1,35 @@
 (ns genegraph.service-test
   (:require [clojure.test :refer :all]
             [io.pedestal.test :refer :all]
-            [io.pedestal.http :as bootstrap]
-            [genegraph.service :as service]))
+            [io.pedestal.http :as server]
+            [genegraph.service :as service]
+            [cheshire.core :as json]
+            [com.walmartlabs.lacinia.schema :as schema]
+            [io.pedestal.test :refer [response-for]])
+  (:import java.time.Instant))
 
+(defn create-query-fn [server]
+  (fn [request variables]
+    (let [response (response-for server
+                                 :post "/graphql"
+                                 :headers {"Content-Type" "application/json"}
+                                 :body (json/generate-string {:query request :variables variables}))]
+      (assoc response :json (json/parse-string (:body response) true)))))
+
+(deftest request-gating-test
+  (let [schema (schema/compile
+                {:queries 
+                 {:hello
+                  {:type 'String
+                   :resolve (fn  [& _]
+                              (let [t (Instant/now)]
+                                (Thread/sleep 100)
+                                (str t)))}}})
+        server (::server/service-fn (server/create-servlet (service/service schema)))
+        query (create-query-fn server)]
+    (let [result (->> (repeatedly promise)
+                      (take 5))]
+      (doseq [r result]
+        (.start (Thread. #(deliver r (query "{hello}" {})))))
+      (testing "Request gate should have one unique result"
+          (is (= 1 (->> result (map #(:body @%)) (into #{}) count)))))))


### PR DESCRIPTION
Adding gate to interceptors so that multiple identical requests make only one query then return the same result for all callers. Will hopefully reduce the instability in the service after a deploy.