### PR TITLE
Remove MONDO:0000001 from genetic conditions for gene

### DIFF
--- a/src/genegraph/source/graphql/common/curation.clj
+++ b/src/genegraph/source/graphql/common/curation.clj
@@ -119,7 +119,8 @@
 
 (defn curated-genetic-conditions-for-gene [query-params]
   (map #(array-map :gene (:gene query-params) :disease %) 
-       (curated-diseases-for-gene query-params)))
+       (remove #(= (q/resource :mondo/Disease) %)
+               (curated-diseases-for-gene query-params))))
 
 (def curated-genes-for-disease
   (create-query [:project ['gene]


### PR DESCRIPTION
Addresses an issue I introduced by mapping Dosage records to MONDO terms, these now show up on the Genetic Conditions list as being curated for 'Disease'

At the core, this issue is caused by a difference between how we're modeling this in SEPIO and how it's being presented in GraphQL. Longer term we will want to address this, but in the short term this fix should meet the need.