### PR TITLE
Clinvar log edits

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,6 @@
                  [com.google.cloud/google-cloud-storage "1.108.0"]
                  [org.rocksdb/rocksdbjni "6.11.4"]
                  [com.taoensso/nippy "3.1.1"]
-                 [com.taoensso/timbre "4.10.0"]
                  [digest "1.4.9"]
                  [com.google.firebase/firebase-admin "7.0.1"]]
   :min-lein-version "2.0.0"

--- a/src/genegraph/source/graphql/clinvar/aggregate_assertion.clj
+++ b/src/genegraph/source/graphql/clinvar/aggregate_assertion.clj
@@ -12,12 +12,12 @@
   When lacinia serializes the resource to a string it receives the iri used to construct the
   resource initially, which in our case is the assertion record iri."
   [context args value]
-  (log/info :fn ::aggregate-assertion-list :args args :value value)
+  (log/debug :fn ::aggregate-assertion-list :args args :value value)
 
   (let [timeframe (let [tf-arg (:timeframe args "LATEST")]
                     (if (some #(= tf-arg %) ["ALL" "LATEST"])
                       tf-arg
-                      (do (log/info :msg "Parsing interval string")
+                      (do (log/debug :msg "Parsing interval string")
                           (log/error :msg "Not yet implemented")
                           (throw (ex-info "Intervals not supported yet, use timeframe ALL or LATEST" {:cause args})))))
         query "PREFIX dc: <http://purl.org/dc/terms/>
@@ -65,7 +65,7 @@
 
 (defn aggregate-assertion-single
   [context args value]
-  (log/info :fn ::aggregate-assertion-single :args args :value value)
+  (log/debug :fn ::aggregate-assertion-single :args args :value value)
   (let [id (resolve-curie-namespace (:id args))
         query "SELECT ?iri WHERE { ?iri :dc/is-version-of ?id }"
         query-args {:id id}]
@@ -73,43 +73,43 @@
 
 (defn version-of
   [context args value]
-  (log/info :fn ::version-of :args args :value value)
+  (log/debug :fn ::version-of :args args :value value)
   (q/ld1-> value [:dc/is-version-of]))
 
 (defn release-date
   [context args value]
-  (log/info :fn ::release-date :args args :value value)
+  (log/debug :fn ::release-date :args args :value value)
   (q/ld1-> value [:cg/release-date]))
 
 (defn subject
   [context args value]
-  (log/info :fn ::subject :args args :value value)
+  (log/debug :fn ::subject :args args :value value)
   (variant/variant-single nil nil (q/ld1-> value [:sepio/has-subject])))
 
 (defn predicate
   [context args value]
-  (log/info :fn ::predicate :args args :value value)
+  (log/debug :fn ::predicate :args args :value value)
   (q/ld1-> value [:sepio/has-predicate]))
 
 (defn object
   [context args value]
-  (log/info :fn ::object :args args :value value)
+  (log/debug :fn ::object :args args :value value)
   (q/ld1-> value [:sepio/has-object]))
 
 (defn review-status
   [context args value]
-  (log/info :fn ::review-status :args args :value value)
+  (log/debug :fn ::review-status :args args :value value)
   (q/ld1-> value [:cg/review-status]))
 
 (defn version
   [context args value]
-  (log/info :fn ::version :args args :value value)
+  (log/debug :fn ::version :args args :value value)
   (q/ld1-> value [:dc/has-version]))
 
 (defn members
   "Expects value to be a RDFResource of the vcv iri."
   [context args value]
-  (log/info :fn ::members :args args :value value)
+  (log/debug :fn ::members :args args :value value)
   (let [query "PREFIX dc: <http://purl.org/dc/terms/>
               PREFIX cg: <http://dataexchange.clinicalgenome.org/terms/>
               PREFIX sepio: <http://purl.obolibrary.org/obo/SEPIO_>

--- a/src/genegraph/source/graphql/clinvar/clinical_assertion.clj
+++ b/src/genegraph/source/graphql/clinvar/clinical_assertion.clj
@@ -12,11 +12,11 @@
   When lacinia serializes the resource to a string it receives the iri used to construct the
   resource initially, which in our case is the assertion record iri."
   [context args value]
-  (log/info :fn ::clinical-assertion-single :args args :value value)
+  (log/debug :fn ::clinical-assertion-single :args args :value value)
   (q/resource (:iri args)))
 
 (defn clinical-assertion-list [context args value]
-  (log/info :fn ::clinical-assertion-list :args args :value value)
+  (log/debug :fn ::clinical-assertion-list :args args :value value)
   (assert (not (nil? (:subject args))) "Subject cannot be nil")
   (assert (not (nil? (:timeframe args))) "Timeframe cannot be nil")
 
@@ -52,34 +52,34 @@
                            subject (q/resource subject))
                 ::q/params {:limit (:limit args)
                             :offset (:offset args)}}]
-    (log/info :spql spql :params params)
+    (log/debug :spql spql :params params)
     (q/select spql params))
   )
 
 (defn version [context args value]
-  (log/info :fn ::version :args args :value value)
+  (log/debug :fn ::version :args args :value value)
   (q/ld1-> value [:dc/has-version])
   )
 
 (defn subject [context args value]
-  (log/info :fn ::subject :args args :value value)
+  (log/debug :fn ::subject :args args :value value)
   (variant/variant-single nil nil (q/ld1-> value [:sepio/has-subject]))
   ;(q/ld1-> value [:sepio/has-subject])
   )
 
 (defn object [context args value]
-  (log/info :fn ::object :args args :value value)
+  (log/debug :fn ::object :args args :value value)
   (q/ld1-> value [:sepio/has-object]))
 
 (defn review-status [context args value]
-  (log/info :fn ::review-status :args args :value value)
+  (log/debug :fn ::review-status :args args :value value)
 
   (let [
         assertion-iri (str value)                           ; returns the iri of the value resource
         ;review-status-resource (q/resource (cgterm "hasReviewStatus"))
         assertion-resource (q/resource assertion-iri)
         ]
-    (log/info :assertion_iri assertion-iri
+    (log/debug :assertion_iri assertion-iri
               :assertion-resource assertion-resource
               ;:review-status-resource review-status-resource
               )
@@ -87,37 +87,37 @@
     ))
 
 (defn date-updated [context args value]
-  (log/info :fn ::date-updated :args args :value value)
+  (log/debug :fn ::date-updated :args args :value value)
   (q/ld1-> value [:sepio/date-updated]))
 
 (defn release-date [context args value]
-  (log/info :fn ::release-date :args args :value value)
+  (log/debug :fn ::release-date :args args :value value)
   (q/ld1-> value [:cg/release-date]))
 
 (defn predicate [context args value]
-  (log/info :fn ::predicate :args args :value value)
+  (log/debug :fn ::predicate :args args :value value)
   (q/ld1-> value [:sepio/has-predicate]))
 
 (defn version-of [context args value]
-  (log/info :fn ::version-of :args args :value value)
+  (log/debug :fn ::version-of :args args :value value)
   (q/ld1-> value [:dc/is-version-of]))
 
 (defn contribution [context args value]
-  (log/info :fn ::contribution :args args :value value)
+  (log/debug :fn ::contribution :args args :value value)
   (let [contribution-resource (q/ld1-> value [:sepio/qualified-contribution])]
-    (log/info :value contribution-resource)
+    (log/debug :value contribution-resource)
     contribution-resource)
   )
 
 (defn allele-origin [context args ^RDFResource value]
-  (log/info :fn ::allele-origin :args args :value value)
+  (log/debug :fn ::allele-origin :args args :value value)
   (let [scv-iri (str value)]
-    ;(log/info "scv: " scv-iri)
+    ;(log/debug "scv: " scv-iri)
     ;(q/select "SELECT ?o WHERE { ?s a :cg/VariantClinicalSignificanceAssertion; : }")
     (q/ld-> value [:cg/allele-origin])
     ))
 
 (defn collection-method [context args value]
-  (log/info :fn ::collection-method :args args :value value)
+  (log/debug :fn ::collection-method :args args :value value)
   (q/ld-> value [:cg/collection-method])
   )

--- a/src/genegraph/source/graphql/clinvar/contribution.clj
+++ b/src/genegraph/source/graphql/clinvar/contribution.clj
@@ -4,7 +4,7 @@
             [io.pedestal.log :as log]))
 
 (defn contribution-single [context args value]
-  (log/info :args args :value value)
+  (log/debug :fn ::contribution-single :args args :value value)
   (q/resource (:iri args)))
 
 ;(defn contribution-list [context args value]
@@ -16,15 +16,15 @@
 ;  )
 
 (defn agent [context args value]
-  (log/info :args args :value value)
+  (log/debug :fn ::agent :args args :value value)
   (q/ld1-> value [:sepio/has-agent]))
 
 (defn agent-role [context args value]
-  (log/info :args args :value value)
+  (log/debug :fn ::agent-role :args args :value value)
   (q/ld1-> value [:sepio/has-role]))
 
 (defn activity-date [context args value]
-  (log/info :args args :value value)
+  (log/debug :fn ::activity-date :args args :value value)
   (q/ld1-> value [:sepio/activity-date]))
 
 

--- a/src/genegraph/source/graphql/clinvar/variant.clj
+++ b/src/genegraph/source/graphql/clinvar/variant.clj
@@ -17,7 +17,7 @@
   TODO
   - :before iso8601 datetime to set cutoff to (will retrieve latest at or before this datetime)"
   [context args value]
-  (log/info :fn ::variant-single :args args :value value)
+  (log/debug :fn ::variant-single :args args :value value)
   (let [value (if (q/resource? value)
                 value
                 (q/resource (resolve-curie-namespace value)))
@@ -45,9 +45,9 @@
                                     (q/resource value))})]
       (if (< 1 (count rs))
         (throw (ex-info "Single variant query returned more than 1 response" {:args args :value value :rs rs})))
-      (log/info :result (first rs))
+      (log/debug :result (first rs))
       (first rs))))
 
 (defn variant-name [context args value]
-  (log/info :fn ::variant-name :args args :value value)
+  (log/debug :fn ::variant-name :args args :value value)
   (q/ld1-> value [:cg/name]))

--- a/src/genegraph/transform/clinvar/common.clj
+++ b/src/genegraph/transform/clinvar/common.clj
@@ -1,10 +1,16 @@
 (ns genegraph.transform.clinvar.common
-  (:require [clojure.tools.logging :as log]
-            [genegraph.database.names :refer [local-property-names local-class-names prefix-ns-map]]))
+  (:require [genegraph.database.names :refer [local-property-names local-class-names prefix-ns-map]]
+            [genegraph.transform.clinvar.iri :as iri]))
 
 (defmulti transform-clinvar :genegraph.transform.clinvar/format)
 
 (defmulti clinvar-to-jsonld :genegraph.transform.clinvar/format)
+
+(def clinvar-jsonld-context {"@context" {"@vocab" iri/cgterms
+                                         "clingen" iri/cgterms
+                                         "sepio" "http://purl.obolibrary.org/obo/SEPIO_"
+                                         "clinvar" "https://www.ncbi.nlm.nih.gov/clinvar/"
+                                         }})
 
 (defn variation-geno-type
   [variation-type]
@@ -23,25 +29,27 @@
   (throw (UnsupportedOperationException. "Not yet implemented")))
 
 (def vcv-review-status-to-evidence-strength-map
-  "Converts clinvar textual VCV review status to a numerical evidence strength
+  "Maps clinvar textual VCV review status to a numerical evidence strength.
+  Any value not contained here should default to a strength of 0.
   https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/"
-  {"practice guideline"                                   4
-   "reviewed by expert panel"                             3
+  {"practice guideline" 4
+   "reviewed by expert panel" 3
    "criteria provided, multiple submitters, no conflicts" 2
-   "criteria provided, single submitter"                  1
-   "criteria provided, conflicting interpretations"       1
-   "no assertion criteria provided"                       0
-   "no assertion for the individual variant"              0
-   "no assertion provided"                                0})
+   "criteria provided, single submitter" 1
+   "criteria provided, conflicting interpretations" 1
+   "no assertion criteria provided" 0
+   "no assertion for the individual variant" 0
+   "no assertion provided" 0})
 (def scv-review-status-to-evidence-strength-map
   "Maps clinvar textual SCV review status to a numerical evidence strength.
+  Any value not contained here should default to a strength of 0.
   https://www.ncbi.nlm.nih.gov/clinvar/docs/review_status/"
-  {"practice guideline"                      4
-   "reviewed by expert panel"                3
-   "criteria provided, single submitter"     1
-   "no assertion criteria provided"          0
+  {"practice guideline" 4
+   "reviewed by expert panel" 3
+   "criteria provided, single submitter" 1
+   "no assertion criteria provided" 0
    "no assertion for the individual variant" 0
-   "no assertion provided"                   0})
+   "no assertion provided" 0})
 
 (defn genegraph-kw-to-iri
   "Uses property-names and class-names to try to resolve keywords in `m`.

--- a/src/genegraph/transform/clinvar/common.clj
+++ b/src/genegraph/transform/clinvar/common.clj
@@ -1,6 +1,7 @@
 (ns genegraph.transform.clinvar.common
   (:require [genegraph.database.names :refer [local-property-names local-class-names prefix-ns-map]]
-            [genegraph.transform.clinvar.iri :as iri]))
+            [genegraph.transform.clinvar.iri :as iri]
+            [io.pedestal.log :as log]))
 
 (defmulti transform-clinvar :genegraph.transform.clinvar/format)
 
@@ -20,7 +21,7 @@
         :geno/Haplotype
         (= "Genotype" variation-type)
         :geno/Genotype
-        :default (do (log/error "Unknown variation type")
+        :default (do (log/error :msg "Unknown variation type")
                      :geno/Allele)))
 
 (defn contribution-role
@@ -81,7 +82,7 @@
                     ; v against local-class-names. If keyword not in those maps, convert keyword to string (name)
                     (let [k2 (resolve-key k)
                           v2 (resolve-value v)]
-                      (log/debugf "%s -> %s, %s -> %s" k k2 v v2)
+                      (log/debug :mapped-values (format "%s -> %s, %s -> %s" k k2 v v2))
                       [k2 v2]))
                   m)))
   )

--- a/src/genegraph/transform/clinvar/core.clj
+++ b/src/genegraph/transform/clinvar/core.clj
@@ -5,7 +5,7 @@
             [genegraph.database.names :refer [prefix-ns-map]]
             [cheshire.core :as json]
             [clojure.java.io :as io]
-            [taoensso.timbre :as log]
+            [io.pedestal.log :as log]
             [genegraph.transform.clinvar.iri :as iri]
             [genegraph.transform.clinvar.common :refer [transform-clinvar clinvar-to-jsonld]]
 
@@ -16,47 +16,27 @@
             )
   (:import (java.io StringReader)))
 
-(defn transform-sentinel
+(defmethod clinvar-to-jsonld :release_sentinel ; sentinel-to-jsonld
   [msg]
   (let [content (:content msg)
         iri (str iri/release-sentinel (:release_date msg))]
     [[iri :cg/clingen-release (:release_date msg)]]))
 
-(defmethod transform-clinvar :default
-  [msg]
-  ; entity_type did not match a defmethod for transform-clinvar
-  (cond
-    (= "release_sentinel" (get msg :type))
-    (do (log/info "Got release sentinel" msg)
-        (transform-sentinel msg))
-    :default
-    (do (log/error (ex-info (str ::format " not known") {:cause msg}))
-        ; Return no triples
-        [])))
-
-;(defmethod add-model :clinvar-raw [event]
-;  (let [model (-> event
-;                  :genegraph.sink.event/value
-;                  (json/parse-string true)
-;                  ((fn [%] (assoc % :genegraph.transform.clinvar/format
-;                                    (keyword (get-in % [:content :entity_type])))))
-;                  transform-clinvar
-;                  ;((fn [triples] (log/info (json/generate-string triples)) triples))
-;                  ; Some statement objects are optional, assume spec already performed,
-;                  ; filter null objects here
-;                  ((fn [triples] (filter #(let [[s p o] %] (not= nil o)) triples)))
-;                  ((fn [triples] (log/info (json/generate-string triples)) triples))
-;                  l/statements-to-model)]
-;    (assoc event ::q/model model)))
-
-;(defmulti transform-clinvar-jsonld :genegraph.transform.clinvar/format)
-;(defmethod transform-clinvar-jsonld :clinical_assertion [record]
-;  (genegraph.transform.clinvar.jsonld.clinical-assertion/t ))
-
+;(defmethod transform-clinvar :default
+;  [msg]
+;  ; entity_type did not match a defmethod for transform-clinvar
+;  (cond
+;    (= "release_sentinel" (get msg :type))
+;    (do (log/debug "Got release sentinel" msg)
+;        (transform-sentinel msg))
+;    :default
+;    (do (log/error (ex-info (str ::format " not known") {:cause msg}))
+;        ; Return no triples
+;        [])))
 
 (defn add-clinvar-format [event]
   (let [cv-format (keyword (get-in event [:entity_type]))]
-    (log/info cv-format)
+    (log/debug :fn ::add-clinvar-format :format cv-format)
     (assoc event :genegraph.transform.clinvar/format cv-format)))
 
 (defn add-clinvar-jsonld
@@ -66,7 +46,7 @@
   (let [jsonld (-> msg
                    add-clinvar-format
                    clinvar-to-jsonld)]
-    (log/info jsonld)
+    (log/info :fn ::add-clinvar-jsonld :jsonld jsonld)
     (assoc msg ::clinvar-jsonld jsonld)))
 
 (defn select-other-keys
@@ -87,33 +67,16 @@
                    :genegraph.sink.stream/topic
                    :genegraph.sink.stream/partition
                    :genegraph.sink.stream/offset]]
-    (log/info "add-model" :clinvar-combined (select-keys event info-keys))
-    (log/debug "add-model" :clinvar-combined (select-other-keys event info-keys)))
+    (log/info :fn ::add-model :dispatch :clinvar-combined :value (select-keys event info-keys))
+    (log/debug :fn ::add-model :dispatch :clinvar-combined :value (select-other-keys event info-keys)))
 
   (let [model (-> event
                   :genegraph.sink.event/value
                   (json/parse-string true)
-                  ;add-clinvar-format
                   add-clinvar-jsonld
                   :genegraph.transform.clinvar.core/clinvar-jsonld
                   ; TODO convert ::clinvar-jsonld to model using l/read-rdf
                   (#(l/read-rdf (StringReader. (json/generate-string %)) {:format :json-ld}))
                   )
         event (assoc event ::q/model model)]
-    ;(log/info event)
     event))
-
-; add-model with manually construct triples
-;(defmethod add-model :clinvar-raw [event]
-;  (let [model (-> event
-;                  :genegraph.sink.event/value
-;                  (json/parse-string true)
-;                  add-clinvar-format
-;                  transform-clinvar
-;                  ;((fn [triples] (log/info (json/generate-string triples)) triples))
-;                  ; Some statement objects are optional, assume spec already performed,
-;                  ; filter null objects here
-;                  ((fn [triples] (filter #(let [[s p o] %] (not= nil o)) triples)))
-;                  ((fn [triples] (log/info (json/generate-string triples)) triples))
-;                  l/statements-to-model)]
-;    (assoc event ::q/model model)))

--- a/src/genegraph/transform/clinvar/jsonld/clinical_assertion.clj
+++ b/src/genegraph/transform/clinvar/jsonld/clinical_assertion.clj
@@ -8,8 +8,7 @@
                                                         genegraph-kw-to-iri
                                                         vcv-review-status-to-evidence-strength-map
                                                         scv-review-status-to-evidence-strength-map]]
-            [genegraph.transform.clinvar.iri :as iri]
-            [taoensso.timbre :as log]))
+            [genegraph.transform.clinvar.iri :as iri]))
 
 (defn clinical-assertion-to-jsonld [msg]
   (let [id (format (str iri/clinvar-assertion "%s.%s")

--- a/src/genegraph/transform/clinvar/jsonld/submission.clj
+++ b/src/genegraph/transform/clinvar/jsonld/submission.clj
@@ -8,8 +8,7 @@
                                                         genegraph-kw-to-iri
                                                         vcv-review-status-to-evidence-strength-map
                                                         scv-review-status-to-evidence-strength-map]]
-            [genegraph.transform.clinvar.iri :as iri]
-            [taoensso.timbre :as log]))
+            [genegraph.transform.clinvar.iri :as iri]))
 
 
 (defn submission-to-jsonld [msg]

--- a/src/genegraph/transform/clinvar/jsonld/variation.clj
+++ b/src/genegraph/transform/clinvar/jsonld/variation.clj
@@ -5,8 +5,7 @@
                                                         clinvar-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri]]
-            [genegraph.transform.clinvar.iri :as iri]
-            [taoensso.timbre :as log]))
+            [genegraph.transform.clinvar.iri :as iri]))
 
 [::id
  ::name

--- a/src/genegraph/transform/clinvar/jsonld/variation_archive.clj
+++ b/src/genegraph/transform/clinvar/jsonld/variation_archive.clj
@@ -5,8 +5,7 @@
                                                         clinvar-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri]]
-            [genegraph.transform.clinvar.iri :as iri]
-            [taoensso.timbre :as log]))
+            [genegraph.transform.clinvar.iri :as iri]))
 
 [:date_created
  :date_last_updated


### PR DESCRIPTION
Downgrade many log calls in clinvar namespaces to debug, improve some log messages.

Remove `timbre` dependency.