### PR TITLE
Gci secondary contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2021-06-14
+
+Incorporate secondary approvers and contributions from GCI data
+
+Add field to GraphQL to represent all contributions for gene validity assertion
+
+Include GCEP and VCEP as well as affiliations
+
 ## 2021-06-02
 
 Updated to incorporate two new actionability assertion types based on rule-outs

--- a/resources/class-names.edn
+++ b/resources/class-names.edn
@@ -69,6 +69,8 @@
  [:sepio/ActionabilityAssertion "http://purl.obolibrary.org/obo/SEPIO_0003003"]
  [:sepio/GeneValidityReport "http://purl.obolibrary.org/obo/SEPIO_0004004"]
  [:sepio/ApproverRole "http://purl.obolibrary.org/obo/SEPIO_0000155"]
+ [:sepio/SecondaryContributorRole "http://purl.obolibrary.org/obo/SEPIO_0004099"]
+ [:sepio/SecondaryApproverRole "http://purl.obolibrary.org/obo/SEPIO_0004112"]
  [:sepio/InterpreterRole "http://purl.obolibrary.org/obo/SEPIO_0000331"]
  [:sepio/GeneticCondition "http://purl.obolibrary.org/obo/SEPIO_0000219"]
  [:sepio/EvidenceRole "http://purl.obolibrary.org/obo/SEPIO_0000148"]

--- a/resources/graphql-schema.edn
+++ b/resources/graphql-schema.edn
@@ -642,6 +642,15 @@ the context of a formal evalutation framework"
     :attributed_to {:type :Agent
                     :resolve :ac-assertion/attributed-to}}}
 
+  :ValidityContribution
+  {:fields
+   {:agent {:type :Agent
+            :resolve :gv-contribution/agent}
+    :realizes {:type :Class
+               :resolve :gv-contribution/realizes}
+    :date {:type String
+           :resolve :gv-contribution/date}}}
+  
   :GeneValidityAssertion
   {:implements [:Resource :Curation :EvidenceItem]
    :fields
@@ -662,6 +671,9 @@ the context of a formal evalutation framework"
     :classification {:type :Classification
                      :description "Final classification of this gene validity curation."
                      :resolve :gene-validity/classification}
+    :contributions {:type (list :ValidityContribution)
+                    :resolve :gene-validity/contributions
+                    :description "All contributions related to this gene validity curation."}
     :gene {:type :Gene
            :description "Gene associated with this curation"
            :resolve :gene-validity/gene}

--- a/src/genegraph/source/graphql/contribution.clj
+++ b/src/genegraph/source/graphql/contribution.clj
@@ -1,0 +1,13 @@
+(ns genegraph.source.graphql.contribution
+  (:require [genegraph.database.query :as q :refer [ld-> ld1-> create-query resource]]
+            [genegraph.source.graphql.common.cache :refer [defresolver]]
+            [clojure.string :as s]))
+
+(defresolver agent [args value]
+  (ld1-> value [:sepio/has-agent]))
+
+(defresolver realizes [args value]
+  (ld1-> value [:bfo/realizes]))
+
+(defresolver date [args value]
+  (ld1-> value [:sepio/activity-date]))

--- a/src/genegraph/source/graphql/core.clj
+++ b/src/genegraph/source/graphql/core.clj
@@ -14,6 +14,7 @@
             [genegraph.source.graphql.region-feature :as region-feature]
             [genegraph.source.graphql.coordinate :as coordinate]
             [genegraph.source.graphql.dosage-proposition :as dosage-proposition]
+            [genegraph.source.graphql.contribution :as contribution]
             [genegraph.source.graphql.condition :as condition]
             [genegraph.source.graphql.server-status :as server-status]
             [genegraph.source.graphql.evidence :as evidence]
@@ -122,6 +123,9 @@
    :condition/superclasses condition/superclasses
    :condition/synonyms condition/synonyms
    :condition/propositions condition/propositions
+   :gv-contribution/agent contribution/agent
+   :gv-contribution/realizes contribution/realizes
+   :gv-contribution/date contribution/date
    :coordinate/assembly coordinate/assembly
    :coordinate/build coordinate/build
    :coordinate/chromosome coordinate/chromosome
@@ -186,6 +190,7 @@
    :gene-feature/previous-symbols gene-feature/previous-symbols
    :gene-validity/attributed-to gene-validity/attributed-to
    :gene-validity/classification gene-validity/classification
+   :gene-validity/contributions  gene-validity/contributions
    :gene-validity/disease gene-validity/disease
    :gene-validity/gene gene-validity/gene
    :gene-validity/gene-validity-assertion-query gene-validity/gene-validity-assertion-query

--- a/src/genegraph/source/graphql/gene_validity.clj
+++ b/src/genegraph/source/graphql/gene_validity.clj
@@ -66,8 +66,23 @@
 (defresolver mode-of-inheritance [args value]
   (ld1-> value [:sepio/has-subject :sepio/has-qualifier]))
 
+;; (defresolver attributed-to [args value]
+  
+;;   (ld1-> value [:sepio/qualified-contribution :sepio/has-agent]))
+
+(def primary-attribution-query
+  (q/create-query
+   "select ?agent where {
+    ?assertion :sepio/qualified-contribution ?contribution . 
+    ?contribution :bfo/realizes :sepio/ApproverRole ;
+    :sepio/has-agent ?agent . } 
+   limit 1 "))
+
 (defresolver attributed-to [args value]
-  (ld1-> value [:sepio/qualified-contribution :sepio/has-agent]))
+  (first (primary-attribution-query {:assertion value})))
+
+(defresolver contributions [args value]
+  (:sepio/qualified-contribution value))
 
 (defresolver specified-by [args value]
   (ld1-> value [:sepio/is-specified-by]))

--- a/src/genegraph/transform/affiliations.clj
+++ b/src/genegraph/transform/affiliations.clj
@@ -6,11 +6,18 @@
 
 (def affiliation-prefix "http://dataexchange.clinicalgenome.org/agent/")
 
+(defn affiliation [[id label]]
+  (if (and (> (count id) 0)
+           (> (count label) 0))
+    (let [iri (str affiliation-prefix id)]
+      [[iri :skos/preferred-label (s/trim label)]
+       [iri :rdf/type :cg/Affiliation]])
+    []))
+
 (defn affiliation-to-triples [affiliation-row]
-  (let [[label id] affiliation-row
-        iri (str affiliation-prefix id)]
-    [[iri :skos/preferred-label (s/trim label)]
-     [iri :rdf/type :cg/Affiliation]]))
+  (let [[label id _ _ _ _ _ vcep-id vcep-label gcep-id gcep-label] affiliation-row
+        affiliation-list [[id label] [vcep-id vcep-label] [gcep-id gcep-label]]]
+    (mapcat affiliation affiliation-list)))
 
 (defn affiliations-to-triples [affiliations-csv]
   (mapcat affiliation-to-triples (rest affiliations-csv)))

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -223,3 +223,14 @@
          (csv/write-csv w))))
 
 
+(defn keys-in [m]
+  (if (map? m)
+    (vec 
+     (mapcat (fn [[k v]]
+               (let [sub (keys-in v)
+                     nested (map #(into [k] %) (filter (comp not empty?) sub))]
+                 (if (seq nested)
+                   nested
+                   [[k]])))
+             m))
+    []))

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -14,7 +14,7 @@
             [genegraph.migration :as migrate]
             [genegraph.sink.rocksdb :as rocks-sink]
             [genegraph.transform.gene-validity :as gene-validity]
-            [genegraph.transform.gene-validity-refactor :as gene-validity-refactor]
+            [genegraph.transform.gci-legacy :as gci-legacy]
             [cheshire.core :as json]
             [clojure.data.csv :as csv]
             [clojure.string :as s]


### PR DESCRIPTION
Resolve #216, adding logic to handle GCEP, VCEP, incorporate secondary approver and contributor from GCI, and represent all contributions using GraphQL.