### PR TITLE
the maintainer docker instruction is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN lein uberjar
 
 # Using image without lein for deployment.
 FROM openjdk:11
-MAINTAINER Tristan Nelson <thnelson@geisinger.edu>
+LABEL maintainer="Tristan Nelson <thnelson@geisinger.edu>"
 
 COPY --from=builder /usr/src/app/target/app.jar /app/app.jar
 COPY keys/dev.serveur.keystore.jks /keys/dev.serveur.keystore.jks


### PR DESCRIPTION
Noticed while looking at various dockery things that Docker has deprecated the `MAINTAINER` instruction, and suggests using a label instead: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated