### PR TITLE
Remove secondary approver from GCI data

### DIFF
--- a/src/genegraph/transform/gci_legacy.clj
+++ b/src/genegraph/transform/gci_legacy.clj
@@ -60,8 +60,7 @@
    [iri :sepio/activity-date (report-date report)]])
 
 (def contributor-roles
-  {"secondary contributor" :sepio/SecondaryContributorRole
-   "secondary approver" :sepio/SecondaryApproverRole})
+  {"secondary contributor" :sepio/SecondaryContributorRole})
 
 (defn secondary-contributions [report assertion-iri]
   (let [roles (set (keys contributor-roles))


### PR DESCRIPTION
The GCI sends secondary approvers with 40000-series ids, and secondary
contributors with 10000-series ids. We are currently standardized on
10000-series ids, so this creates a problem. There is no use case
currently for secondary approvers, so removing this data should
present no problem in the short to medium term.