### PR TITLE
Fix segregation data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Project related
+.cpcache/**
 /db/
 /data/
 /base/

--- a/resources/batch-events.edn
+++ b/resources/batch-events.edn
@@ -1,15 +1,13 @@
 [
- {:name "gci-neo4j-archive"
+ {:name :gci-neo4j-archive
   :source "gci-neo4j-archive.tar.gz"
   :type :compressed-event-files}
 
- {:name "gci-raw-snapshot"
+ {:name :gci-raw-snapshot
   :source "gci_snapshot_events_may_2020.tar.gz"
   :type :compressed-event-files}
  
- {:name "gci-express-json"
+ {:name :gci-express-json
   :source "ClinGen-Gene-Expess-Data-01092020.json"
   :type :json-event-sequence
-  :format :gci-express}
-
- ]
+  :format :gci-express}]

--- a/src/genegraph/transform/gene_validity_refactor/construct_cc_and_seg_assertions.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_cc_and_seg_assertions.sparql
@@ -7,7 +7,7 @@ construct
   ?caseControlEvidenceLine a :sepio/OverallCaseControlEvidenceLine ;
   :sepio/evidence-line-strength-score ?caseControlTotal .
 
-  ?segregationEvidenceLine a :sepio/OverallSegregationEvidenceLine ;
+  ?segregationEvidenceLine a :sepio/SegregationEvidenceLine ;
   :sepio/evidence-line-strength-score ?segregationTotal .
   
 }
@@ -16,7 +16,7 @@ where
 
   ?classification a gci:provisionalClassification .
 
-  BIND (IRI(CONCAT(str(?classification), "_genetic_evidence_overall_evidence_line")) AS ?geneticEvidenceLine) .
+  BIND (IRI(CONCAT(str(?classification), "_overall_genetic_evidence_line")) AS ?geneticEvidenceLine) .
   
   ?classification gci:classificationPoints ?pointsTree .
 


### PR DESCRIPTION
A couple errors in the query linking segregation data meant that the data did not get the appropriate type, or get linked to the overall assertion appropriately. This PR fixes this.