### PR TITLE
Fixes to some Genegraph issues

### DIFF
--- a/src/genegraph/service.clj
+++ b/src/genegraph/service.clj
@@ -225,6 +225,8 @@
 (defn service-map [interceptors subscription-interceptors gql-schema]
   (-> {:env :dev,
        ::http/host "0.0.0.0"
+       ::http/allowed-origins {:allowed-origins (constantly true)
+                               :creds true}
        :io.pedestal.http/routes
        (set/union
         (lacinia-pedestal/graphiql-asset-routes "/assets/graphiql")

--- a/src/genegraph/source/graphql/schema/bibliographic_resource.clj
+++ b/src/genegraph/source/graphql/schema/bibliographic_resource.clj
@@ -4,7 +4,7 @@
 (defn short-citation [_ _ value]
   (if-let [creator (q/ld1-> value [:dc/creator])]
     (str
-     (re-find #"^\w+" creator)
+     (second (re-find #"^(.*)\W(\w+)$" creator))
      " "
      (q/ld1-> value [:dc/date]))))
 

--- a/src/genegraph/transform/gene_validity_refactor/construct_functional_alteration_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_functional_alteration_evidence.sparql
@@ -22,8 +22,9 @@ where {
   # gci:experimental_scored ?gciEvidence .
 
   OPTIONAL  {
-    ?gciScore gci:score ?adjustedScore .
+    ?evidenceLine gci:score ?adjustedScore .
   }
+  
   BIND(COALESCE(?adjustedScore, ?calculatedScore) AS ?score) .
 
   ?evidenceItem gci:scores ?evidenceLine ;

--- a/src/genegraph/transform/gene_validity_refactor/construct_model_systems_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_model_systems_evidence.sparql
@@ -33,7 +33,7 @@ where {
   ?gciEvidence gci:modelSystems ?gciModelSystem  ;
   gci:label ?evidenceLabel .
 
-  ?gciModelSystem gci:descriptionOfGeneAlteration ?evidenceDescription ;
+  ?gciModelSystem gci:explanation ?evidenceDescription ;
   gci:modelSystemsType ?gciType .
 
   ?evidenceLineType gcixform:hasGCIType ?gciType ;

--- a/src/genegraph/transform/gene_validity_refactor/construct_rescue_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_rescue_evidence.sparql
@@ -20,7 +20,7 @@ where {
   }
 
   OPTIONAL  {
-    ?gciScore gci:score ?adjustedScore .
+    ?evidenceLine gci:score ?adjustedScore .
   }
   
   BIND(COALESCE(?adjustedScore, ?calculatedScore) AS ?score) .

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -22,7 +22,7 @@
             [clojure.string :as s]
             [clojure.set :as set]
             [clojure.spec.alpha :as spec]
-            ;; [cognitect.rebl :as rebl]
+            [cognitect.rebl :as rebl]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.java.io :as io]
@@ -33,8 +33,8 @@
   (:import java.time.Instant
            org.apache.jena.rdf.model.AnonId))
 
-;; (defn start-rebl []
-;;   (rebl/ui))
+(defn start-rebl []
+  (rebl/ui))
 
 (defn clear-named-grpahs-with-type [type-carrying-graph-name]
   (let [named-graphs (map str


### PR DESCRIPTION
Fixes:
* Open the CORS limitations so that Genegraph-ui can use HTTPS to connect to GraphQL
* Change the author display so that the short citation can accommodate author names with two words.
* Fix bug with score for some types of experimental evidence
* Fix description issues for some types of experimental evidence