### PR TITLE
Fix experimental evidence descriptions

### DIFF
--- a/src/genegraph/sink/base.clj
+++ b/src/genegraph/sink/base.clj
@@ -39,9 +39,13 @@
 (defn retrieve-base-data! [resources]
   (doall (pmap (fn [resource]
                  (let [{uri-str :source, target-file :target, opts :fetch-opts, name :name} resource
-                      path (str (target-base) target-file)]
+                       path (str (target-base) target-file)]
                    (io/make-parents path)
-                   (fetch/fetch-data uri-str path opts))) resources)))
+                   (try
+                     (fetch/fetch-data uri-str path opts)
+                     (catch Exception e
+                       (log/error :fn :retrieve-base-data :resource name)
+                       (throw e))))) resources)))
 
 (defn import-documents! [documents]
   (doall (pmap (fn [d]

--- a/src/genegraph/transform/gene_validity_refactor/construct_functional_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_functional_evidence.sparql
@@ -28,6 +28,21 @@ where {
   ?evidenceItem gci:scores ?evidenceLine ;
   gci:label ?evidenceLabel ;
   gci:evidenceType ?gciType .
+
+  OPTIONAL {
+    ?evidenceItem gci:biochemicalFunction / gci:evidenceForFunction ?biochemicalFunctionDescription .
+  }
+
+  OPTIONAL {
+    ?evidenceItem gci:proteinInteractions / gci:relationshipOfOtherGenesToDisese ?proteinInteractionDescription .
+  }
+
+  OPTIONAL {
+    ?evidenceItem gci:expression / gci:alteredExpression / gci:evidence ?expressionDescription .
+  }
+  
+  
+  BIND(COALESCE(?expressionDescription, ?proteinInteractionDescription, ?biochemicalFunctionDescription) AS ?evidenceDescription) .
   
   ?evidenceLineType gcixform:hasGCIType ?gciType ;
   gcixform:hasEvidenceItemType ?evidenceItemType ;

--- a/src/genegraph/transform/gene_validity_refactor/construct_rescue_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_rescue_evidence.sparql
@@ -29,7 +29,7 @@ where {
   gci:rescue ?gciRescue  ;
   gci:label ?evidenceLabel .
 
-  ?gciRescue gci:rescueMethod ?evidenceDescription ;
+  ?gciRescue gci:explanation ?evidenceDescription ;
   gci:rescueType ?gciType .
 
   ?evidenceLineType gcixform:hasGCIType ?gciType ;


### PR DESCRIPTION
Resolves #307 ,correcting the mapping of description labels for certain evidence types. Also notes the items on which the pull of base items for a migration may be failing.