### PR TITLE
Date for old gv assertions

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -55,12 +55,15 @@
   juxt/dirwatch {:mvn/version "0.2.5"}
   ;; for generating jsonld context
   org.flatland/ordered {:mvn/version "1.5.7"}
+
+  ;; Alternative to REBL
+  djblue/portal {:mvn/version "0.18.1"}
   ;; REBL reqs
-  ;; org.openjfx/javafx-fxml {:mvn/version "17"}
-  ;; org.openjfx/javafx-controls {:mvn/version "17"}
-  ;; org.openjfx/javafx-swing {:mvn/version "17"}
-  ;; org.openjfx/javafx-base {:mvn/version "17"}
-  ;; org.openjfx/javafx-web {:mvn/version "17"}
+  ;; org.openjfx/javafx-fxml {:mvn/version "17.0.1"}
+  ;; org.openjfx/javafx-controls {:mvn/version "17.0.1"}
+  ;; org.openjfx/javafx-swing {:mvn/version "17.0.1"}
+  ;; org.openjfx/javafx-base {:mvn/version "17.0.1"}
+  ;; org.openjfx/javafx-web {:mvn/version "17.0.1"}
   ;; org.openjfx/javafx-fxml     {:mvn/version "15-ea+6"}
   ;; org.openjfx/javafx-controls {:mvn/version "15-ea+6"}
   ;; org.openjfx/javafx-swing    {:mvn/version "15-ea+6"}

--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
@@ -17,7 +17,7 @@ construct {
 
   ?contribution :sepio/has-agent ?affiliation ;
   :bfo/realizes :sepio/ApproverRole ;
-  :sepio/activity-date ?classificationDate .
+  :sepio/activity-date ?date .
 
   ?autoClassification a :sepio/GeneValidityEvidenceLevelAutoClassification ;
   :sepio/has-subject ?proposition ;
@@ -39,8 +39,17 @@ where {
   gci:evidenceSummary ?description ;
   gci:autoClassification ?autoEvidenceLevel ;
   gci:alteredClassification ?alteredEvidenceLevel ;
-  gci:classificationDate ?classificationDate ;
   gci:classificationPoints ?pointsTree .
+
+  OPTIONAL {
+    ?classification gci:classificationDate ?classificationDate .
+  }
+
+  OPTIONAL {
+    ?classification gci:approvalDate ?approvalDate .
+  }
+
+  BIND(COALESCE(?classificationDate, ?approvalDate) AS ?date)
 
   BIND(IF(?alteredEvidenceLevel = gcixform:NoModification, ?autoEvidenceLevel, ?alteredEvidenceLevel) AS ?evidencelevel) .
 

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -23,10 +23,12 @@
             [clojure.set :as set]
             [clojure.spec.alpha :as spec]
             ;; [cognitect.rebl :as rebl]
+;;            [portal.api :as p]
             [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
+            [clojure.datafy :as d]
             [taoensso.nippy :as nippy]
             [genegraph.database.names :as db-names]
             [genegraph.database.property-store :as property-store])


### PR DESCRIPTION
Resolves  #335

Assertions weren't showing up for all old gv curations, as the expected classification date field is not present for these.