### PR TITLE
Establish unpublish for GV, fix iri for older curations

### DIFF
--- a/src/genegraph/annotate/action.clj
+++ b/src/genegraph/annotate/action.clj
@@ -22,3 +22,10 @@
              "Retracted" :unpublish
              "In Preparation" :no-action
              :publish))))
+
+(defmethod add-action :gci-refactor [event]
+  (let [action (if (re-find #"\"publishClassification\":true"
+                            (:genegraph.sink.event/value event))
+                 :publish
+                 :unpublish)]
+    (assoc event :genegraph.annotate/action action)))

--- a/src/genegraph/transform/gene_validity_refactor.clj
+++ b/src/genegraph/transform/gene_validity_refactor.clj
@@ -61,6 +61,7 @@
 
             "PK" "@id"
             "item_type" "@type"
+            "uuid" "@id"
 
             
             "gci" "http://dataexchange.clinicalgenome.org/gci/"
@@ -143,7 +144,8 @@
 
 (defn parse-gdm [gdm-json]
   (let [gdm-with-fixed-curies (-> gdm-json
-                                  (s/replace #"MONDO_" "MONDO:"))
+                                  (s/replace #"MONDO_" "MONDO:")
+                                  (s/replace #"@id" "gciid"))
         is (-> (str context "," (subs gdm-with-fixed-curies 1))
                .getBytes
                ByteArrayInputStream.)]


### PR DESCRIPTION
Resolves #249 #303 

Establishes unpublish action, changes ID sources for old curations to align with newer curations.