### PR TITLE
Remove additional snapshots

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -55,7 +55,8 @@
   juxt/dirwatch {:mvn/version "0.2.5"}
   ;; for generating jsonld context
   org.flatland/ordered {:mvn/version "1.5.7"}
-
+  com.apicatalog/titanium-json-ld {:mvn/version "1.1.0"}
+  org.glassfish/jakarta.json {:mvn/version "2.0.1"}
   ;; Alternative to REBL
   djblue/portal {:mvn/version "0.18.1"}
   ;; REBL reqs

--- a/src/genegraph/annotate/action.clj
+++ b/src/genegraph/annotate/action.clj
@@ -24,7 +24,7 @@
              :publish))))
 
 (defmethod add-action :gci-refactor [event]
-  (let [action (if (re-find #"\"publishClassification\":true"
+  (let [action (if (re-find #"\"publishClassification\": ?true"
                             (:genegraph.sink.event/value event))
                  :publish
                  :unpublish)]

--- a/src/genegraph/source/graphql/schema/find.clj
+++ b/src/genegraph/source/graphql/schema/find.clj
@@ -22,6 +22,11 @@
    :DISEASE :mondo/Disease
    :AFFILIATION :cg/Affiliation})
 
+(defn args->resource [args keys]
+  (->> (select-keys args keys)
+       (map (fn [[k v]] [k (q/resource v)]))
+       (into {})))
+
 (defn query [_ args _]
   (let [limit-offset-sort-params (-> args
                                     (select-keys [:limit :offset :sort])
@@ -29,8 +34,8 @@
         query-params (-> (if (string? (:text args))
                            {:text (s/lower-case (:text args))}
                            {})
-                         (assoc :type (graphql-type-to-rdf-type (:type args))
-                                ::q/params limit-offset-sort-params))
+                         (merge (args->resource args [:type]))
+                         (assoc ::q/params limit-offset-sort-params))
         query (if (:text args)
                 query-with-text-search
                 query-without-text-search)
@@ -61,7 +66,7 @@
    :description "Query useable to find any kind of resource in Genegraph, including genes, dieseases, affiliation groups."
    :type :QueryResult
    :skip-type-resolution true
-   :args {:type {:type :Type}
+   :args {:type {:type 'String}
           :text {:type 'String}
           :limit {:type 'Int
                   :default-value 10

--- a/src/genegraph/transform/gene_validity_refactor/construct_functional_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_functional_evidence.sparql
@@ -38,7 +38,7 @@ where {
   }
 
   OPTIONAL {
-    ?evidenceItem gci:expression / gci:alteredExpression / gci:evidence ?expressionDescription .
+    ?evidenceItem gci:expression / ( gci:alteredExpression | gci:normalExpression )  / gci:evidence ?expressionDescription .
   }
   
   

--- a/src/genegraph/transform/gene_validity_refactor/construct_model_systems_evidence.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_model_systems_evidence.sparql
@@ -28,10 +28,11 @@ where {
   BIND(COALESCE(?adjustedScore, ?calculatedScore) AS ?score) .
   
   ?evidenceItem gci:scores ?evidenceLine ;
+  gci:modelSystems ?gciModelSystem  ;
   gci:label ?evidenceLabel .
   
-  ?gciEvidence gci:modelSystems ?gciModelSystem  ;
-  gci:label ?evidenceLabel .
+  # ?gciEvidence gci:modelSystems ?gciModelSystem  ;
+  # gci:label ?evidenceLabel .
 
   ?gciModelSystem gci:explanation ?evidenceDescription ;
   gci:modelSystemsType ?gciType .
@@ -40,7 +41,7 @@ where {
   gcixform:hasEvidenceItemType ?evidenceItemType ;
   gcixform:usedIn gcixform:ModelSystems .
   
-  ?annotation gci:experimentalData ?gciEvidence ;
+  ?annotation gci:experimentalData ?evidenceItem ;
   gci:article ?publication .
   ?publication gci:pmid ?pmid .
   BIND(IRI(CONCAT(?pmbase, ?pmid)) AS ?article) .


### PR DESCRIPTION
This one fixes an issue where Gene Validity curations would sometimes have multiple historic versions contained in the same message that would all get smooshed together, making it impossible for Genegraph to sort out which was the most current.

Just added some code that clips the key that stores these old snapshots. Did a little refactoring to clean up the code while in there. Also added a bit of code to accommodate messages in the GCI format we're expecting new messages in.