### PR TITLE
Use only published curations

### DIFF
--- a/src/genegraph/transform/gene_validity_refactor.clj
+++ b/src/genegraph/transform/gene_validity_refactor.clj
@@ -225,7 +225,8 @@
                         (construct-articles params) 
                         (construct-secondary-contributions params)
                         (construct-variant-score params)
-                        (construct-unscoreable-evidence params))]
+                        (construct-unscoreable-evidence params)
+                        )]
     (q/union unlinked-model
              (construct-evidence-connections 
               {::q/model

--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
@@ -41,6 +41,7 @@ where {
   
   ?classification a gci:provisionalClassification ;
   gci:approvedClassification true ;
+  gci:publishClassification true ;
   gci:autoClassification ?autoEvidenceLevel ;
   gci:alteredClassification ?alteredEvidenceLevel ;
   gci:classificationPoints ?pointsTree .


### PR DESCRIPTION
Addresses #370 , some legacy curations had historically been attached to the message snapshot, but were not flagged as published. This filters for just the ones that are intended to be published.