### PR TITLE
update leiningen to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # For more information on these images, and use of Clojure in Docker
 # https://hub.docker.com/_/clojure
-FROM clojure:openjdk-11-lein-2.9.6 AS builder
+FROM clojure:openjdk-11-lein-2.9.8 AS builder
 
 # Copying and building deps as a separate step in order to mitigate
 # the need to download new dependencies every build.


### PR DESCRIPTION
Back in October, we pinned our lein docker image to version 2.9.6 to work around a bug in 2.9.7 (https://github.com/technomancy/leiningen/issues/2769)

Now that it's resolved, we should be able to update. I still think there's value in pinning the release, just so we don't get an unexpected update in the future that breaks us.