### PR TITLE
Handle case where actionability score does not exist

### DIFF
--- a/src/genegraph/transform/actionability.clj
+++ b/src/genegraph/transform/actionability.clj
@@ -109,7 +109,7 @@
        flatten
        (map :Total)
        flatten
-       (map #(re-find #"\d+" %))
+       (map #(or (re-find #"\d+" %) "0"))
        (map #(Integer/parseInt %))
        (map #(vector (:iri curation) :cg/has-total-actionability-score %))))
 


### PR DESCRIPTION
Resolves #445 

It seems that some actionability assertions may not included a numeric score for a gene, disease, intervention set. Adding branch to accommodate this instance.