### PR TITLE
not sure we need the omim genemap presently

### DIFF
--- a/resources/base.edn
+++ b/resources/base.edn
@@ -138,10 +138,10 @@
   :target "hgnc.json",
   :format :genes,
   :fetch-opts {:accept :json}}
- {:name "https://omim.org/genemap2"
-  :source "https://data.omim.org/downloads/U7rx7IRhSIah-gm1M-yBDA/genemap2.txt"
-  :target "genemap2.txt"
-  :format :omim-genemap}
+ ;; {:name "https://omim.org/genemap2"
+ ;;  :source "https://data.omim.org/downloads/U7rx7IRhSIah-gm1M-yBDA/genemap2.txt"
+ ;;  :target "genemap2.txt"
+ ;;  :format :omim-genemap}
  {:name "http://dataexchange.clinicalgenome.org/terms"
   :source "https://raw.githubusercontent.com/clingen-data-model/clingen-terms/master/clingen-terms.ttl"
   :target "clingen-terms.ttl"


### PR DESCRIPTION
storing the key in the clear on github is anyways a problem. Should
probably remove until at least there is another mechanism for pulling
data for genegraph builds