### PR TITLE
Make `clj -T:build uber` work.

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -9,7 +9,7 @@
   (b/delete {:path "target"}))
 
 (defn uber [_]
-  (clean nil)
+  (clean _)
   (b/copy-dir {:src-dirs ["src" "resources" "config"]
                :target-dir class-dir})
   (b/compile-clj {:basis basis

--- a/deps.edn
+++ b/deps.edn
@@ -7,12 +7,14 @@
   {:url "https://repo.clojars.org/"}
   "cognitect-dev-tools"
   {:url "https://dev-tools.cognitect.com/maven/releases/"}}
- :paths
- ["src" "resources" "config"]
+
+ :paths ["src" "resources" "config"]
+
  :aliases
+
  {:build
-  {:extra-deps {io.github.clojure/tools.build     {:tag "v0.8.1"
-                                                   :sha "7d40500"}}
+  {:extra-deps {io.github.clojure/tools.build       {:tag "v0.8.1"
+                                                     :sha "7d40500"}}
    :ns-default build}
 
   :format

--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,6 @@
   com.taoensso/nippy                              {:mvn/version "3.1.1"}
   com.velisco/clj-ftp                             {:mvn/version "0.3.17"} ; For downloading ftp docs
   com.walmartlabs/lacinia-pedestal                {:mvn/version "1.0"}
-  commons-codec/commons-codec                     {:mvn/version "1.15"} ; Req by Jena--not in deps
   digest/digest                                   {:mvn/version "1.4.10"}
   ;; alternative to REBL
   djblue/portal                                   {:mvn/version "0.23.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -37,6 +37,7 @@
   com.fasterxml.jackson.core/jackson-databind     {:mvn/version "2.13.2"}
   com.github.danielwegener/logback-kafka-appender {:mvn/version "0.2.0-RC2"}
   com.google.cloud/google-cloud-storage           {:mvn/version "2.6.0"}
+  ;; :exclusions works around LICENSE/license filename case conflict in build.
   com.google.firebase/firebase-admin              {:mvn/version "8.1.0"
                                                    :exclusions
                                                    [io.grpc/grpc-netty-shaded]}

--- a/deps.edn
+++ b/deps.edn
@@ -34,7 +34,7 @@
   {:extra-deps  {io.pedestal/pedestal.service-tools {:mvn/version "0.5.5"}}
    :main-opts   ["-m" "genegraph.server/run-dev"]}
 
-  :test
+  :test                                 ; clj -M:test all
   {:extra-deps  {lambdaisland/kaocha                {:mvn/version "1.66.1034"}}
    :extra-paths ["test"]
    :main-opts   ["-m" "kaocha.runner"]}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,9 +17,23 @@
                                                      :sha "7d40500"}}
    :ns-default build}
 
+  :eastwood                             ; clj -M:eastwood
+  {:extra-deps {jonase/eastwood                     {:mvn/version "1.2.3"}}
+   :extra-paths ["test"]
+   :main-opts ["-m" "eastwood.lint" :source-paths ["src" "test"]]}
+
   :format                               ; clj -M:format
-  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+  {:extra-deps {cljfmt/cljfmt                       {:mvn/version "0.8.0"}}
+   :extra-paths ["test"]
    :main-opts  ["-m" "cljfmt.main" "fix"]}
+
+  :kondo                                ; clj -M:kondo
+  {:extra-deps {clj-kondo/clj-kondo                 {:mvn/version "2022.04.25"}}
+   :main-opts ["-m" "clj-kondo.main"]}
+
+  :kibit                                ; clj -M:kibit
+  {:extra-deps  {jonase/kibit                       {:mvn/version "0.1.8"}}
+   :main-opts   ["-e" "(use,'kibit.driver),(external-run,[\"src\"],nil)"]}
 
   :rebl                                 ; for JDK 11+
   {:extra-deps {com.cognitect/rebl                  {:mvn/version "0.9.245"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,88 +1,91 @@
-{:mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}
-             "clojars" {:url "https://repo.clojars.org/"}
-             "bintray" {:url "http://jcenter.bintray.com"}}
- :paths ["src" "resources" "config"]
+{:mvn/repos
+ {"bintray"
+  {:url "http://jcenter.bintray.com"}
+  "central"
+  {:url "https://repo1.maven.org/maven2/"}
+  "clojars"
+  {:url "https://repo.clojars.org/"}
+  "cognitect-dev-tools"
+  {:url "https://dev-tools.cognitect.com/maven/releases/"}}
+ :paths
+ ["src" "resources" "config"]
  :aliases
- {:build {:deps {io.github.clojure/tools.build {:tag "v0.5.1" :sha "599be6c"}}
-          :ns-default build}
-  :rebl        ;; for JDK 11+
-  {:extra-deps {com.cognitect/rebl          {:mvn/version "0.9.242"}
-                org.openjfx/javafx-fxml     {:mvn/version "17"}
-                org.openjfx/javafx-controls {:mvn/version "17"}
-                org.openjfx/javafx-swing    {:mvn/version "17"}
-                org.openjfx/javafx-base     {:mvn/version "17"}
-                org.openjfx/javafx-web      {:mvn/version "17"}}
-   :main-opts ["-m" "cognitect.rebl"]}
-  ;; :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.6.0"}}}
-  ;; :nrebl {:extra-deps {nrepl/nrepl {:mvn/version "RELEASE"}
-  ;;                      cider/cider-nrepl {:mvn/version "0.21.0"}
-  ;;                      refactor-nrepl {:mvn/version "2.4.0"}
-  ;;                      rickmoynihan/nrebl.middleware {:mvn/version "0.2.0"}}
-  ;;         :main-opts ["-e" "((requiring-resolve,'cognitect.rebl/ui))" "-m" "nrepl.cmdline" "-i" "--middleware" "[nrebl.middleware/wrap-nrebl,cider.nrepl/cider-middleware]"]}
-  }
+ {:build
+  {:deps       {io.github.clojure/tools.build     {:tag "v0.8.1"
+                                                   :sha "7d40500"}}
+   :ns-default build}
+  :rebl                                 ; for JDK 11+
+  {:extra-deps {com.cognitect/rebl                {:mvn/version "0.9.245"}
+                org.openjfx/javafx-base           {:mvn/version "18"}
+                org.openjfx/javafx-controls       {:mvn/version "18"}
+                org.openjfx/javafx-fxml           {:mvn/version "18"}
+                org.openjfx/javafx-swing          {:mvn/version "18"}
+                org.openjfx/javafx-web            {:mvn/version "18"}}
+   :main-opts ["-m" "cognitect.rebl"]}}
  :deps
- {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/core.async {:mvn/version "1.3.610" :exclusions [org.clojure/tools.reader]}
-  io.pedestal/pedestal.service {:mvn/version "0.5.8"}
-  io.pedestal/pedestal.jetty {:mvn/version "0.5.8"}
-  io.pedestal/pedestal.interceptor {:mvn/version "0.5.8"}
-  hiccup/hiccup {:mvn/version "1.0.5"}
-  ch.qos.logback/logback-classic {:mvn/version "1.2.3" :exclusions [org.slf4j/slf4j-api]}
-  org.slf4j/jul-to-slf4j {:mvn/version "1.7.26"}
-  org.slf4j/jcl-over-slf4j {:mvn/version "1.7.26"}
-  org.slf4j/log4j-over-slf4j {:mvn/version "1.7.26"}
+ {
+  org.clojure/clojure                             {:mvn/version "1.11.1"}
+  org.clojure/core.async                          {:mvn/version "1.5.648"
+                                                   :exclusions
+                                                   [org.clojure/tools.reader]}
+  org.clojure/data.csv                            {:mvn/version "1.0.1"}
+  buddy/buddy-sign                                {:mvn/version "3.4.333"}
+  camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}
+  ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"
+                                                   :exclusions
+                                                   [org.slf4j/slf4j-api]}
+  cheshire/cheshire                               {:mvn/version "5.10.2"}
+  clj-commons/fs                                  {:mvn/version "1.6.310"}
+  clj-http/clj-http                               {:mvn/version "3.12.3"} ; For downloading
+  com.apicatalog/titanium-json-ld                 {:mvn/version "1.3.0"}
+  com.fasterxml.jackson.core/jackson-core         {:mvn/version "2.13.2"}
+  com.fasterxml.jackson.core/jackson-databind     {:mvn/version "2.13.2"}
   com.github.danielwegener/logback-kafka-appender {:mvn/version "0.2.0-RC2"}
-  org.apache.kafka/kafka-clients {:mvn/version "3.1.0"}
-  cheshire/cheshire {:mvn/version "5.8.1"}
-  org.clojure/data.csv {:mvn/version "0.1.4"}
-  camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.0"}
-  org.apache.jena/jena-text {:mvn/version "3.17.0" :exclusions [org.apache.jena/jena-cmds org.apache.jena/apache-jena-libs]}
-  org.apache.jena/jena-tdb2 {:mvn/version "3.17.0"}
-  org.apache.jena/jena-tdb {:mvn/version "3.17.0"}
-  org.apache.jena/jena-arq {:mvn/version "3.17.0"}
-  org.apache.jena/jena-core {:mvn/version "3.17.0"}
-  org.apache.jena/jena-iri {:mvn/version "3.17.0"}
-  org.apache.lucene/lucene-suggest {:mvn/version "7.7.3"} ;; jena 3.14.0 includes lucene 7.4.0
-  commons-codec/commons-codec {:mvn/version "1.15"} ;; Req by Jena--not in deps
-  ;; Dependency superceeded by antlr provided via lacinia dependency
-  org.topbraid/shacl {:mvn/version "1.3.2" :exclusions [org.antlr/antlr4-runtime]}
-  mount/mount {:mvn/version "0.1.16"}
-  com.velisco/clj-ftp {:mvn/version "0.3.9"} ;; For downloading ftp docs
-  clj-http/clj-http {:mvn/version "3.9.1"} ;; For downloading 
-  com.walmartlabs/lacinia-pedestal {:mvn/version "0.15.0"}
-  clj-commons/fs {:mvn/version "1.5.2"}
-  ;; Dirwatch for updating base files in development
-  juxt/dirwatch {:mvn/version "0.2.5"}
-  ;; for generating jsonld context
-  org.flatland/ordered {:mvn/version "1.5.7"}
-  com.apicatalog/titanium-json-ld {:mvn/version "1.1.0"}
-  org.glassfish/jakarta.json {:mvn/version "2.0.1"}
-  ;; Alternative to REBL
-  djblue/portal {:mvn/version "0.18.1"}
-  ;; REBL reqs
-  ;; org.openjfx/javafx-fxml {:mvn/version "17.0.1"}
-  ;; org.openjfx/javafx-controls {:mvn/version "17.0.1"}
-  ;; org.openjfx/javafx-swing {:mvn/version "17.0.1"}
-  ;; org.openjfx/javafx-base {:mvn/version "17.0.1"}
-  ;; org.openjfx/javafx-web {:mvn/version "17.0.1"}
-  ;; org.openjfx/javafx-fxml     {:mvn/version "15-ea+6"}
-  ;; org.openjfx/javafx-controls {:mvn/version "15-ea+6"}
-  ;; org.openjfx/javafx-swing    {:mvn/version "15-ea+6"}
-  ;; org.openjfx/javafx-base     {:mvn/version "15-ea+6"}
-  ;; org.openjfx/javafx-web      {:mvn/version "15-ea+6"}
-  ;; com.cognitect/rebl {:local/root "jars/rebl-0.9.242.jar"}
-  ;; /REBL Reqs
-  expound/expound {:mvn/version "0.7.2"}
-  medley/medley {:mvn/version "1.3.0"}
-  buddy/buddy-sign {:mvn/version "3.2.0"}
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.11.0"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.11.0"}
-  com.google.cloud/google-cloud-storage {:mvn/version "2.6.1"}
+  com.google.cloud/google-cloud-storage           {:mvn/version "2.6.0"}
+  com.google.firebase/firebase-admin              {:mvn/version "8.1.0"
+                                                   :exclusions
+                                                   [io.grpc/grpc-netty-shaded]}
+  com.taoensso/nippy                              {:mvn/version "3.1.1"}
+  com.velisco/clj-ftp                             {:mvn/version "0.3.17"} ; For downloading ftp docs
+  com.walmartlabs/lacinia-pedestal                {:mvn/version "1.0"}
+  commons-codec/commons-codec                     {:mvn/version "1.15"} ; Req by Jena--not in deps
+  digest/digest                                   {:mvn/version "1.4.10"}
+  ;; alternative to REBL
+  djblue/portal                                   {:mvn/version "0.23.0"}
+  expound/expound                                 {:mvn/version "0.9.0"}
+  hiccup/hiccup                                   {:mvn/version "2.0.0-alpha2"}
   ;; rocksjni for everything else -- is there an arch switch in deps?
   ;;  org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
   ;; rocksjni for apple silicon--will not work on Intel
-  io.maryk.rocksdb/rocksdbjni {:mvn/version "6.17.0"}
-  com.taoensso/nippy {:mvn/version "3.1.1"}
-  digest/digest {:mvn/version "1.4.9"}
-  com.google.firebase/firebase-admin {:mvn/version "7.0.1"}
-  org.codehaus.janino/janino {:mvn/version "3.1.3"}}}
+  io.maryk.rocksdb/rocksdbjni                     {:mvn/version "6.25.3"}
+  io.pedestal/pedestal.interceptor                {:mvn/version "0.5.10"}
+  io.pedestal/pedestal.jetty                      {:mvn/version "0.5.10"}
+  io.pedestal/pedestal.service                    {:mvn/version "0.5.10"}
+  ;; dirwatch for updating base files in development
+  juxt/dirwatch                                   {:mvn/version "0.2.5"}
+  medley/medley                                   {:mvn/version "1.4.0"}
+  mount/mount                                     {:mvn/version "0.1.16"}
+  org.apache.jena/jena-arq                        {:mvn/version "3.17.0"}
+  org.apache.jena/jena-core                       {:mvn/version "3.17.0"}
+  org.apache.jena/jena-iri                        {:mvn/version "3.17.0"}
+  org.apache.jena/jena-tdb                        {:mvn/version "3.17.0"}
+  org.apache.jena/jena-tdb2                       {:mvn/version "3.17.0"}
+  org.apache.jena/jena-text                       {:mvn/version "3.17.0"
+                                                   :exclusions
+                                                   [#_org.apache.jena/jena-cmds
+                                                    org.apache.jena/apache-jena-libs]}
+  org.apache.kafka/kafka-clients                  {:mvn/version "3.1.0"}
+  org.apache.lucene/lucene-suggest                {:mvn/version "9.1.0"} ;; jena 3.14.0 includes lucene 7.4.0
+  org.codehaus.janino/janino                      {:mvn/version "3.1.6"}
+  ;; for generating jsonld context
+  org.flatland/ordered                            {:mvn/version "1.15.10"}
+  org.glassfish/jakarta.json                      {:mvn/version "2.0.1"}
+  org.slf4j/jcl-over-slf4j                        {:mvn/version "1.7.36"}
+  org.slf4j/jul-to-slf4j                          {:mvn/version "1.7.36"}
+  org.slf4j/log4j-over-slf4j                      {:mvn/version "1.7.36"}
+  ;; dependency superceeded by antlr provided via lacinia dependency
+  org.topbraid/shacl                              {:mvn/version "1.4.2"
+                                                   :exclusions
+                                                   [org.antlr/antlr4-runtime]}
+  }
+ }

--- a/deps.edn
+++ b/deps.edn
@@ -14,73 +14,84 @@
   {:extra-deps {io.github.clojure/tools.build     {:tag "v0.8.1"
                                                    :sha "7d40500"}}
    :ns-default build}
+
   :format
   {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
    :main-opts  ["-m" "cljfmt.main" "fix"]}
+
   :rebl                                 ; for JDK 11+
-  {:extra-deps {com.cognitect/rebl                {:mvn/version "0.9.245"}
-                org.openjfx/javafx-base           {:mvn/version "18"}
-                org.openjfx/javafx-controls       {:mvn/version "18"}
-                org.openjfx/javafx-fxml           {:mvn/version "18"}
-                org.openjfx/javafx-swing          {:mvn/version "18"}
-                org.openjfx/javafx-web            {:mvn/version "18"}}
-   :main-opts ["-m" "cognitect.rebl"]}}
+  {:extra-deps {com.cognitect/rebl                  {:mvn/version "0.9.245"}
+                org.openjfx/javafx-base             {:mvn/version "18"}
+                org.openjfx/javafx-controls         {:mvn/version "18"}
+                org.openjfx/javafx-fxml             {:mvn/version "18"}
+                org.openjfx/javafx-swing            {:mvn/version "18"}
+                org.openjfx/javafx-web              {:mvn/version "18"}}
+   :main-opts ["-m" "cognitect.rebl"]}
+
+  :run
+  {:extra-deps  {io.pedestal/pedestal.service-tools {:mvn/version "0.5.5"}}
+   :main-opts   ["-m" "genegraph.server/run-dev"]}
+
+  :test
+  {:extra-deps  {lambdaisland/kaocha                {:mvn/version "1.66.1034"}}
+   :extra-paths ["test"]
+   :main-opts   ["-m" "kaocha.runner"]}}
 
  :deps
- {org.clojure/clojure                             {:mvn/version "1.11.1"}
-  org.clojure/core.async                          {:mvn/version "1.5.648"}
-  org.clojure/data.csv                            {:mvn/version "1.0.1"}
-  camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}
-  ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"}
+ {org.clojure/clojure                               {:mvn/version "1.11.1"}
+  org.clojure/core.async                            {:mvn/version "1.5.648"}
+  org.clojure/data.csv                              {:mvn/version "1.0.1"}
+  camel-snake-kebab/camel-snake-kebab               {:mvn/version "0.4.2"}
+  ch.qos.logback/logback-classic                    {:mvn/version "1.2.11"}
   ;; Why not just clojure.data.json? =tbl
-  cheshire/cheshire                               {:mvn/version "5.10.2"}
+  cheshire/cheshire                                 {:mvn/version "5.10.2"}
   ;; fs included for delete-dir and mkdirs. =tbl
-  clj-commons/fs                                  {:mvn/version "1.6.310"}
+  clj-commons/fs                                    {:mvn/version "1.6.310"}
   ;; For downloading
-  clj-http/clj-http                               {:mvn/version "3.12.3"}
-  com.apicatalog/titanium-json-ld                 {:mvn/version "1.3.0"}
-  com.fasterxml.jackson.core/jackson-core         {:mvn/version "2.13.2"}
-  com.fasterxml.jackson.core/jackson-databind     {:mvn/version "2.13.2"}
-  com.github.danielwegener/logback-kafka-appender {:mvn/version "0.2.0-RC2"}
-  com.google.cloud/google-cloud-storage           {:mvn/version "2.6.0"}
+  clj-http/clj-http                                 {:mvn/version "3.12.3"}
+  com.apicatalog/titanium-json-ld                   {:mvn/version "1.3.0"}
+  com.fasterxml.jackson.core/jackson-core           {:mvn/version "2.13.2"}
+  com.fasterxml.jackson.core/jackson-databind       {:mvn/version "2.13.2"}
+  com.github.danielwegener/logback-kafka-appender   {:mvn/version "0.2.0-RC2"}
+  com.google.cloud/google-cloud-storage             {:mvn/version "2.6.0"}
   ;; :exclusions works around LICENSE/license filename case conflict in build.
-  com.google.firebase/firebase-admin              {:mvn/version "8.1.0"
-                                                   :exclusions
-                                                   [io.grpc/grpc-netty-shaded]}
-  com.taoensso/nippy                              {:mvn/version "3.1.1"}
+  com.google.firebase/firebase-admin                {:mvn/version "8.1.0"
+                                                     :exclusions
+                                                     [io.grpc/grpc-netty-shaded]}
+  com.taoensso/nippy                                {:mvn/version "3.1.1"}
   ;; Included for downloading ftp docs with miner.ftp. =tbl
-  com.velisco/clj-ftp                             {:mvn/version "0.3.17"}
-  com.walmartlabs/lacinia-pedestal                {:mvn/version "1.0"}
-  digest/digest                                   {:mvn/version "1.4.10"}
+  com.velisco/clj-ftp                               {:mvn/version "0.3.17"}
+  com.walmartlabs/lacinia-pedestal                  {:mvn/version "1.0"}
+  digest/digest                                     {:mvn/version "1.4.10"}
   ;; alternative to REBL
-  djblue/portal                                   {:mvn/version "0.23.0"}
+  djblue/portal                                     {:mvn/version "0.23.0"}
   ;; rocksjni for everything else -- is there an arch switch in deps?
   ;; org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
-  ;; rocksjni for apple silicon--will not work on Intel
-  io.maryk.rocksdb/rocksdbjni                     {:mvn/version "6.25.3"}
-  io.pedestal/pedestal.interceptor                {:mvn/version "0.5.10"}
-  io.pedestal/pedestal.jetty                      {:mvn/version "0.5.10"}
-  io.pedestal/pedestal.service                    {:mvn/version "0.5.10"}
-  ;; dirwatch for updating base files in development
-  juxt/dirwatch                                   {:mvn/version "0.2.5"}
+  ;; rocksjni for apple silicon--will not work onIntel
+  io.maryk.rocksdb/rocksdbjni                       {:mvn/version "6.25.3"}
+  io.pedestal/pedestal.interceptor                  {:mvn/version "0.5.10"}
+  io.pedestal/pedestal.jetty                        {:mvn/version "0.5.10"}
+  io.pedestal/pedestal.service                      {:mvn/version "0.5.10"}
+  ;; dirwatch for updating base files in developme  nt
+  juxt/dirwatch                                     {:mvn/version "0.2.5"}
   ;; medley included for filter-keys and deep-merge. =tbl
-  medley/medley                                   {:mvn/version "1.4.0"}
-  mount/mount                                     {:mvn/version "0.1.16"}
-  org.apache.jena/jena-arq                        {:mvn/version "3.17.0"}
-  org.apache.jena/jena-core                       {:mvn/version "3.17.0"}
-  org.apache.jena/jena-iri                        {:mvn/version "3.17.0"}
-  org.apache.jena/jena-tdb                        {:mvn/version "3.17.0"}
-  org.apache.jena/jena-tdb2                       {:mvn/version "3.17.0"}
-  org.apache.jena/jena-text                       {:mvn/version "3.17.0"}
-  org.apache.kafka/kafka-clients                  {:mvn/version "3.1.0"}
+  medley/medley                                     {:mvn/version "1.4.0"}
+  mount/mount                                       {:mvn/version "0.1.16"}
+  org.apache.jena/jena-arq                          {:mvn/version "3.17.0"}
+  org.apache.jena/jena-core                         {:mvn/version "3.17.0"}
+  org.apache.jena/jena-iri                          {:mvn/version "3.17.0"}
+  org.apache.jena/jena-tdb                          {:mvn/version "3.17.0"}
+  org.apache.jena/jena-tdb2                         {:mvn/version "3.17.0"}
+  org.apache.jena/jena-text                         {:mvn/version "3.17.0"}
+  org.apache.kafka/kafka-clients                    {:mvn/version "3.1.0"}
   ;; Jena 3.17.0 includes codecs from Lucene 7.7.3. =tbl
-  org.apache.lucene/lucene-suggest                {:mvn/version "7.7.3"}
-  org.codehaus.janino/janino                      {:mvn/version "3.1.6"}
+  org.apache.lucene/lucene-suggest                  {:mvn/version "7.7.3"}
+  org.codehaus.janino/janino                        {:mvn/version "3.1.6"}
   ;; ordered included for generating jsonld context with ordered-map. =tbl
-  org.flatland/ordered                            {:mvn/version "1.15.10"}
-  org.glassfish/jakarta.json                      {:mvn/version "2.0.1"}
-  org.slf4j/jcl-over-slf4j                        {:mvn/version "1.7.36"}
-  org.slf4j/jul-to-slf4j                          {:mvn/version "1.7.36"}
-  org.slf4j/log4j-over-slf4j                      {:mvn/version "1.7.36"}
+  org.flatland/ordered                              {:mvn/version "1.15.10"}
+  org.glassfish/jakarta.json                        {:mvn/version "2.0.1"}
+  org.slf4j/jcl-over-slf4j                          {:mvn/version "1.7.36"}
+  org.slf4j/jul-to-slf4j                            {:mvn/version "1.7.36"}
+  org.slf4j/log4j-over-slf4j                        {:mvn/version "1.7.36"}
   ;; dependency superceeded by antlr provided via lacinia dependency
-  org.topbraid/shacl                              {:mvn/version "1.4.2"}}}
+  org.topbraid/shacl                                {:mvn/version "1.4.2"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,7 @@
   :eastwood                             ; clj -M:eastwood
   {:extra-deps {jonase/eastwood                     {:mvn/version "1.2.3"}}
    :extra-paths ["test"]
-   :main-opts ["-m" "eastwood.lint" :source-paths ["src" "test"]]}
+   :main-opts ["-m" "eastwood.lint" {:source-paths ["src" "test"]}]}
 
   :format                               ; clj -M:format
   {:extra-deps {cljfmt/cljfmt                       {:mvn/version "0.8.0"}}

--- a/deps.edn
+++ b/deps.edn
@@ -27,7 +27,7 @@
    :extra-paths ["test"]
    :main-opts  ["-m" "cljfmt.main" "fix"]}
 
-  :kondo                                ; clj -M:kondo
+  :kondo                                ; clj -M:kondo --lint .
   {:extra-deps {clj-kondo/clj-kondo                 {:mvn/version "2022.04.25"}}
    :main-opts ["-m" "clj-kondo.main"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -69,7 +69,7 @@
   com.fasterxml.jackson.core/jackson-core           {:mvn/version "2.13.2"}
   com.fasterxml.jackson.core/jackson-databind       {:mvn/version "2.13.2"}
   com.github.danielwegener/logback-kafka-appender   {:mvn/version "0.2.0-RC2"}
-  com.google.cloud/google-cloud-storage             {:mvn/version "2.6.0"}
+  com.google.cloud/google-cloud-storage             {:mvn/version "2.6.1"}
   ;; :exclusions works around LICENSE/license filename case conflict in build.
   com.google.firebase/firebase-admin                {:mvn/version "8.1.0"
                                                      :exclusions

--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,8 @@
   org.apache.jena/jena-tdb2                       {:mvn/version "3.17.0"}
   org.apache.jena/jena-text                       {:mvn/version "3.17.0"}
   org.apache.kafka/kafka-clients                  {:mvn/version "3.1.0"}
-  org.apache.lucene/lucene-suggest                {:mvn/version "9.1.0"} ; jena 3.14.0 includes lucene 7.4.0
+  ;; Jena 3.17.0 includes codecs from Lucene 7.7.3.
+  org.apache.lucene/lucene-suggest                {:mvn/version "7.7.3"}
   org.codehaus.janino/janino                      {:mvn/version "3.1.6"}
   ;; for generating jsonld context
   org.flatland/ordered                            {:mvn/version "1.15.10"}

--- a/deps.edn
+++ b/deps.edn
@@ -26,7 +26,6 @@
  {org.clojure/clojure                             {:mvn/version "1.11.1"}
   org.clojure/core.async                          {:mvn/version "1.5.648"}
   org.clojure/data.csv                            {:mvn/version "1.0.1"}
-  buddy/buddy-sign                                {:mvn/version "3.4.333"}
   camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}
   ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"}
   cheshire/cheshire                               {:mvn/version "5.10.2"}
@@ -42,13 +41,12 @@
                                                    :exclusions
                                                    [io.grpc/grpc-netty-shaded]}
   com.taoensso/nippy                              {:mvn/version "3.1.1"}
-  com.velisco/clj-ftp                             {:mvn/version "0.3.17"} ; For downloading ftp docs
+  ;; For downloading ftp docs with miner.ftp.
+  com.velisco/clj-ftp                             {:mvn/version "0.3.17"}
   com.walmartlabs/lacinia-pedestal                {:mvn/version "1.0"}
   digest/digest                                   {:mvn/version "1.4.10"}
   ;; alternative to REBL
   djblue/portal                                   {:mvn/version "0.23.0"}
-  expound/expound                                 {:mvn/version "0.9.0"}
-  hiccup/hiccup                                   {:mvn/version "2.0.0-alpha2"}
   ;; rocksjni for everything else -- is there an arch switch in deps?
   ;;  org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
   ;; rocksjni for apple silicon--will not work on Intel

--- a/deps.edn
+++ b/deps.edn
@@ -12,12 +12,12 @@
 
  :aliases
 
- {:build
-  {:extra-deps {io.github.clojure/tools.build       {:tag "v0.8.1"
+ {:build                                ; clj -T:build uber
+  {:deps       {io.github.clojure/tools.build       {:tag "v0.8.1"
                                                      :sha "7d40500"}}
    :ns-default build}
 
-  :format
+  :format                               ; clj -M:format
   {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
    :main-opts  ["-m" "cljfmt.main" "fix"]}
 
@@ -30,7 +30,7 @@
                 org.openjfx/javafx-web              {:mvn/version "18"}}
    :main-opts ["-m" "cognitect.rebl"]}
 
-  :run
+  :run                                  ; This doesn't work yet.
   {:extra-deps  {io.pedestal/pedestal.service-tools {:mvn/version "0.5.5"}}
    :main-opts   ["-m" "genegraph.server/run-dev"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -23,17 +23,12 @@
                 org.openjfx/javafx-web            {:mvn/version "18"}}
    :main-opts ["-m" "cognitect.rebl"]}}
  :deps
- {
-  org.clojure/clojure                             {:mvn/version "1.11.1"}
-  org.clojure/core.async                          {:mvn/version "1.5.648"
-                                                   :exclusions
-                                                   [org.clojure/tools.reader]}
+ {org.clojure/clojure                             {:mvn/version "1.11.1"}
+  org.clojure/core.async                          {:mvn/version "1.5.648"}
   org.clojure/data.csv                            {:mvn/version "1.0.1"}
   buddy/buddy-sign                                {:mvn/version "3.4.333"}
   camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}
-  ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"
-                                                   :exclusions
-                                                   [org.slf4j/slf4j-api]}
+  ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"}
   cheshire/cheshire                               {:mvn/version "5.10.2"}
   clj-commons/fs                                  {:mvn/version "1.6.310"}
   clj-http/clj-http                               {:mvn/version "3.12.3"} ; For downloading
@@ -70,12 +65,9 @@
   org.apache.jena/jena-iri                        {:mvn/version "3.17.0"}
   org.apache.jena/jena-tdb                        {:mvn/version "3.17.0"}
   org.apache.jena/jena-tdb2                       {:mvn/version "3.17.0"}
-  org.apache.jena/jena-text                       {:mvn/version "3.17.0"
-                                                   :exclusions
-                                                   [#_org.apache.jena/jena-cmds
-                                                    org.apache.jena/apache-jena-libs]}
+  org.apache.jena/jena-text                       {:mvn/version "3.17.0"}
   org.apache.kafka/kafka-clients                  {:mvn/version "3.1.0"}
-  org.apache.lucene/lucene-suggest                {:mvn/version "9.1.0"} ;; jena 3.14.0 includes lucene 7.4.0
+  org.apache.lucene/lucene-suggest                {:mvn/version "9.1.0"} ; jena 3.14.0 includes lucene 7.4.0
   org.codehaus.janino/janino                      {:mvn/version "3.1.6"}
   ;; for generating jsonld context
   org.flatland/ordered                            {:mvn/version "1.15.10"}
@@ -84,8 +76,4 @@
   org.slf4j/jul-to-slf4j                          {:mvn/version "1.7.36"}
   org.slf4j/log4j-over-slf4j                      {:mvn/version "1.7.36"}
   ;; dependency superceeded by antlr provided via lacinia dependency
-  org.topbraid/shacl                              {:mvn/version "1.4.2"
-                                                   :exclusions
-                                                   [org.antlr/antlr4-runtime]}
-  }
- }
+  org.topbraid/shacl                              {:mvn/version "1.4.2"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -110,4 +110,11 @@
   org.slf4j/jul-to-slf4j                            {:mvn/version "1.7.36"}
   org.slf4j/log4j-over-slf4j                        {:mvn/version "1.7.36"}
   ;; dependency superceeded by antlr provided via lacinia dependency
-  org.topbraid/shacl                                {:mvn/version "1.4.2"}}}
+  org.topbraid/shacl                                {:mvn/version "1.4.2"}
+  ;; Support running REBL from the REPL.
+  com.cognitect/rebl                                {:mvn/version "0.9.245"}
+  org.openjfx/javafx-base                           {:mvn/version "18"}
+  org.openjfx/javafx-controls                       {:mvn/version "18"}
+  org.openjfx/javafx-fxml                           {:mvn/version "18"}
+  org.openjfx/javafx-swing                          {:mvn/version "18"}
+  org.openjfx/javafx-web                            {:mvn/version "18"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -11,9 +11,12 @@
  ["src" "resources" "config"]
  :aliases
  {:build
-  {:deps       {io.github.clojure/tools.build     {:tag "v0.8.1"
+  {:extra-deps {io.github.clojure/tools.build     {:tag "v0.8.1"
                                                    :sha "7d40500"}}
    :ns-default build}
+  :format
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+   :main-opts  ["-m" "cljfmt.main" "fix"]}
   :rebl                                 ; for JDK 11+
   {:extra-deps {com.cognitect/rebl                {:mvn/version "0.9.245"}
                 org.openjfx/javafx-base           {:mvn/version "18"}
@@ -22,6 +25,7 @@
                 org.openjfx/javafx-swing          {:mvn/version "18"}
                 org.openjfx/javafx-web            {:mvn/version "18"}}
    :main-opts ["-m" "cognitect.rebl"]}}
+
  :deps
  {org.clojure/clojure                             {:mvn/version "1.11.1"}
   org.clojure/core.async                          {:mvn/version "1.5.648"}

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,8 @@
   cheshire/cheshire                               {:mvn/version "5.10.2"}
   ;; fs included for delete-dir and mkdirs. =tbl
   clj-commons/fs                                  {:mvn/version "1.6.310"}
-  clj-http/clj-http                               {:mvn/version "3.12.3"} ; For downloading
+  ;; For downloading
+  clj-http/clj-http                               {:mvn/version "3.12.3"}
   com.apicatalog/titanium-json-ld                 {:mvn/version "1.3.0"}
   com.fasterxml.jackson.core/jackson-core         {:mvn/version "2.13.2"}
   com.fasterxml.jackson.core/jackson-databind     {:mvn/version "2.13.2"}
@@ -50,7 +51,7 @@
   ;; alternative to REBL
   djblue/portal                                   {:mvn/version "0.23.0"}
   ;; rocksjni for everything else -- is there an arch switch in deps?
-  ;;  org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
+  ;; org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
   ;; rocksjni for apple silicon--will not work on Intel
   io.maryk.rocksdb/rocksdbjni                     {:mvn/version "6.25.3"}
   io.pedestal/pedestal.interceptor                {:mvn/version "0.5.10"}

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,9 @@
   org.clojure/data.csv                            {:mvn/version "1.0.1"}
   camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}
   ch.qos.logback/logback-classic                  {:mvn/version "1.2.11"}
+  ;; Why not just clojure.data.json? =tbl
   cheshire/cheshire                               {:mvn/version "5.10.2"}
+  ;; fs included for delete-dir and mkdirs. =tbl
   clj-commons/fs                                  {:mvn/version "1.6.310"}
   clj-http/clj-http                               {:mvn/version "3.12.3"} ; For downloading
   com.apicatalog/titanium-json-ld                 {:mvn/version "1.3.0"}
@@ -41,7 +43,7 @@
                                                    :exclusions
                                                    [io.grpc/grpc-netty-shaded]}
   com.taoensso/nippy                              {:mvn/version "3.1.1"}
-  ;; For downloading ftp docs with miner.ftp.
+  ;; Included for downloading ftp docs with miner.ftp. =tbl
   com.velisco/clj-ftp                             {:mvn/version "0.3.17"}
   com.walmartlabs/lacinia-pedestal                {:mvn/version "1.0"}
   digest/digest                                   {:mvn/version "1.4.10"}
@@ -56,6 +58,7 @@
   io.pedestal/pedestal.service                    {:mvn/version "0.5.10"}
   ;; dirwatch for updating base files in development
   juxt/dirwatch                                   {:mvn/version "0.2.5"}
+  ;; medley included for filter-keys and deep-merge. =tbl
   medley/medley                                   {:mvn/version "1.4.0"}
   mount/mount                                     {:mvn/version "0.1.16"}
   org.apache.jena/jena-arq                        {:mvn/version "3.17.0"}
@@ -65,10 +68,10 @@
   org.apache.jena/jena-tdb2                       {:mvn/version "3.17.0"}
   org.apache.jena/jena-text                       {:mvn/version "3.17.0"}
   org.apache.kafka/kafka-clients                  {:mvn/version "3.1.0"}
-  ;; Jena 3.17.0 includes codecs from Lucene 7.7.3.
+  ;; Jena 3.17.0 includes codecs from Lucene 7.7.3. =tbl
   org.apache.lucene/lucene-suggest                {:mvn/version "7.7.3"}
   org.codehaus.janino/janino                      {:mvn/version "3.1.6"}
-  ;; for generating jsonld context
+  ;; ordered included for generating jsonld context with ordered-map. =tbl
   org.flatland/ordered                            {:mvn/version "1.15.10"}
   org.glassfish/jakarta.json                      {:mvn/version "2.0.1"}
   org.slf4j/jcl-over-slf4j                        {:mvn/version "1.7.36"}

--- a/project.clj
+++ b/project.clj
@@ -3,70 +3,74 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "1.3.610" :exclusions [org.clojure/tools.reader]]
-                 [io.pedestal/pedestal.service "0.5.8"]
-                 [io.pedestal/pedestal.jetty "0.5.8"]
-                 [io.pedestal/pedestal.interceptor "0.5.8"]
-                 [hiccup "1.0.5"]
-                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jul-to-slf4j "1.7.26"]
-                 [org.slf4j/jcl-over-slf4j "1.7.26"]
-                 [org.slf4j/log4j-over-slf4j "1.7.26"]
-                 [com.github.danielwegener/logback-kafka-appender "0.2.0-RC2"]
-                 [org.apache.kafka/kafka-clients "3.1.0"]
-                 [cheshire "5.8.1"]
-                 [org.clojure/data.csv "0.1.4"]
-                 [camel-snake-kebab "0.4.0"]
-                 [org.apache.jena/jena-text "3.17.0" :exclusions [org.apache.jena/jena-cmds]]
-                 [org.apache.jena/jena-tdb2 "3.17.0"]
-                 [org.apache.jena/jena-arq "3.17.0"]
-                 [org.apache.jena/jena-core "3.17.0"]
-                 [org.apache.jena/jena-iri "3.17.0"]
-                 [org.apache.lucene/lucene-suggest "7.7.3"] ;; jena 3.14.0 includes lucene 7.4.0
-                 [commons-codec/commons-codec "1.15"] ;; Req by Jena--not in deps
-                 ;; Dependency superceeded by antlr provided via lacinia dependency
-                 [org.topbraid/shacl "1.3.2" :exclusions [org.antlr/antlr4-runtime]]
-                 [mount "0.1.16"]
-                 [com.velisco/clj-ftp "0.3.9"] ;; For downloading ftp docs
-                 [clj-http "3.9.1"] ;; For downloading
-                 [com.walmartlabs/lacinia-pedestal "0.15.0"]
-                 [clj-commons/fs "1.5.2"]
-                 ;; Dirwatch for updating base files in development
-                 [juxt/dirwatch "0.2.5"]
-                 ;; for generating jsonld context
-                 [org.flatland/ordered "1.5.7"]
-                 [com.apicatalog/titanium-json-ld "1.1.0"]
-                 [org.glassfish/jakarta.json "2.0.1"]
-                 ;; REBL reqs
-                 [lein-cljfmt "0.6.4"]
-                 [org.openjfx/javafx-fxml "16"]
-                 [org.openjfx/javafx-controls "16"]
-                 [org.openjfx/javafx-swing "16"]
-                 [org.openjfx/javafx-base "16"]
-                 [org.openjfx/javafx-web "16"]
-                 [expound "0.7.2"]
-                 [medley "1.3.0"]
-                 [buddy/buddy-sign "3.2.0"]
-                 [com.fasterxml.jackson.core/jackson-core "2.11.0"]
-                 [com.fasterxml.jackson.core/jackson-databind "2.11.0"]
-                 [com.google.cloud/google-cloud-storage "1.108.0"]
-                 [org.rocksdb/rocksdbjni "6.11.4"]
-                 [com.taoensso/nippy "3.1.1"]
-                 [digest "1.4.9"]
-                 [com.google.firebase/firebase-admin "7.0.1"]
-                 [org.codehaus.janino/janino "3.1.3"]]
+  :dependencies
+  [[org.clojure/clojure "1.11.1"]
+   [org.clojure/core.async "1.5.648"]
+   [org.clojure/data.csv "1.0.1"]
+   [camel-snake-kebab "0.4.2"]
+   [ch.qos.logback/logback-classic "1.2.11"]
+   ;; Why not just clojure.data.json? =tbl
+   [cheshire "5.10.2"]
+   ;; fs included for delete-dir and mkdirs. =tbl
+   [clj-commons/fs "1.6.310"]
+   [clj-http "3.12.3"] ;; For downloading
+   [com.apicatalog/titanium-json-ld "1.3.0"]
+   [com.fasterxml.jackson.core/jackson-core "2.13.2"]
+   [com.fasterxml.jackson.core/jackson-databind "2.13.2"]
+   [com.github.danielwegener/logback-kafka-appender "0.2.0-RC2"]
+   [com.google.cloud/google-cloud-storage "2.6.0"]
+   ;; :exclusions works around LICENSE/license filename case conflict in build.
+   [com.google.firebase/firebase-admin "8.1.0"
+    :exclusions [io.grpc/grpc-netty-shaded]]
+   [com.taoensso/nippy "3.1.1"]
+   [com.velisco/clj-ftp "0.3.17"] ;; For downloading ftp docs
+   [com.walmartlabs/lacinia-pedestal "1.0"]
+   [digest "1.4.10"]
+   [io.maryk.rocksdb/rocksdbjni "6.25.3"]
+   [io.pedestal/pedestal.interceptor "0.5.10"]
+   [io.pedestal/pedestal.jetty "0.5.10"]
+   [io.pedestal/pedestal.service "0.5.10"]
+   ;; Dirwatch for updating base files in development
+   [juxt/dirwatch "0.2.5"]
+   [lein-cljfmt "0.8.0"]
+   ;; medley included for filter-keys and deep-merge. =tbl
+   [medley "1.4.0"]
+   [mount "0.1.16"]
+   [org.apache.jena/jena-arq "3.17.0"]
+   [org.apache.jena/jena-core "3.17.0"]
+   [org.apache.jena/jena-iri "3.17.0"]
+   [org.apache.jena/jena-tdb2 "3.17.0"]
+   [org.apache.jena/jena-text "3.17.0"]
+   [org.apache.kafka/kafka-clients "3.1.0"]
+   ;; Jena 3.17.0 includes codecs from Lucene 7.7.3. =tbl
+   [org.apache.lucene/lucene-suggest "7.7.3"]
+   [org.codehaus.janino/janino "3.1.6"]
+   ;; ordered included for generating jsonld context with ordered-map. =tbl
+   [org.flatland/ordered "1.15.10"]
+   [org.glassfish/jakarta.json "2.0.1"]
+   [org.slf4j/jcl-over-slf4j "1.7.36"]
+   [org.slf4j/jul-to-slf4j "1.7.36"]
+   [org.slf4j/log4j-over-slf4j "1.7.36"]
+   ;; dependency superceeded by antlr provided via lacinia dependency
+   [org.topbraid/shacl "1.4.2"]
+   ;; REBL reqs
+   [org.openjfx/javafx-base     "16"]
+   [org.openjfx/javafx-controls "16"]
+   [org.openjfx/javafx-fxml     "16"]
+   [org.openjfx/javafx-swing    "16"]
+   [org.openjfx/javafx-web      "16"]]
   :min-lein-version "2.0.0"
   :resource-paths ["config", "resources", "jars/rebl-0.9.242.jar"]
-  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
-  ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
-  :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "genegraph.server/run-dev"]}
-                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.5"]]}
-             :uberjar {:aot [genegraph.server]
-                       :uberjar-name "app.jar"}}
+  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct
+  ;; alpn-boot dependency
+  ;; :java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
+  :profiles
+  {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "genegraph.server/run-dev"]}
+         :dependencies [[io.pedestal/pedestal.service-tools "0.5.5"]]}
+   :uberjar {:aot [genegraph.server]
+             :uberjar-name "app.jar"}}
   :repl-options {:caught clojure.repl/pst}
   :plugins [[lein-codox "0.10.7"]]
   :codox {:output-path "docs"}
   :jvm-opts ["-XX:MaxRAMPercentage=50"]
   :main ^{:skip-aot true} genegraph.server)
-

--- a/src/genegraph/database/load.clj
+++ b/src/genegraph/database/load.clj
@@ -1,20 +1,19 @@
 (ns genegraph.database.load
-  (:require [mount.core :as mount :refer [defstate]]
+  (:require [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
-            [camel-snake-kebab.core :as csk]
-            [clojure.java.io :as io]
             [genegraph.database.instance :refer [db]]
-            [genegraph.database.property-store :as property-store]
-            [genegraph.database.util :refer [property tx write-tx]]
             [genegraph.database.names :refer [local-property-names local-class-names]]
+            [genegraph.database.property-store :as property-store]
             [genegraph.database.query :as q]
+            [genegraph.database.util :refer [property tx write-tx]]
             [genegraph.database.validation :as v]
-            [io.pedestal.log :as log])
-  (:import [org.apache.jena.tdb2 TDB2Factory]
+            [io.pedestal.log :as log]
+            [mount.core :as mount :refer [defstate]])
+  (:import [org.apache.jena.ontology OntResource]
            [org.apache.jena.query TxnType Dataset]
-           [org.apache.jena.rdf.model Model ModelFactory Literal Resource ResourceFactory
-            Statement]
-           [org.apache.jena.ontology OntResource]))
+           [org.apache.jena.rdf.model Model ModelFactory Literal Resource
+            ResourceFactory Statement]
+           [org.apache.jena.tdb2 TDB2Factory]))
 
 (def jena-rdf-format
   {:rdf-xml "RDF/XML"

--- a/src/genegraph/server.clj
+++ b/src/genegraph/server.clj
@@ -13,7 +13,7 @@
 
 (def initialized? (atom false))
 
-(def status-routes 
+(def status-routes
   {::server/routes
    [["/live"
      :get (fn [_] {:status 200 :body "server is live"})
@@ -32,7 +32,7 @@
                       "production" (service/prod-service)
                       "transformer" (service/transformer-service)
                       (service/dev-service))]
-    (server/start 
+    (server/start
      (server/create-server
       (merge-with into service-map status-routes)))))
 
@@ -104,7 +104,7 @@
   (env/log-environment)
   (when env/migration-data-version
     (with-redefs [env/data-vol env/migration-data-vol
-                  env/data-version env/migration-data-version] 
+                  env/data-version env/migration-data-version]
       (migration/populate-data-vol-if-needed)))
   (migration/create-migration))
 
@@ -116,4 +116,3 @@
       (run-server-transformer nil)
       (run-server-genegraph nil))
     (run-migration)))
-

--- a/src/genegraph/source/graphql/experimental_schema.clj
+++ b/src/genegraph/source/graphql/experimental_schema.clj
@@ -70,7 +70,7 @@
 (defn schema-description []
   (schema-builder/schema-description model))
 
-(defn query 
+(defn query
   "Function not used except for evaluating queries in the REPL
   may consider moving into test namespace in future"
   ([query-str]

--- a/src/genegraph/transform/clinvar/core.clj
+++ b/src/genegraph/transform/clinvar/core.clj
@@ -10,27 +10,27 @@
                                                         clinvar-to-model
                                                         clinvar-model-to-jsonld]]
             [genegraph.transform.clinvar.util :as util]
-    ;[genegraph.transform.clinvar.variation-archive]
+            ;;[genegraph.transform.clinvar.variation-archive]
             [genegraph.transform.clinvar.variation]
             [genegraph.database.load :as l]))
 
-;(defmethod clinvar-to-jsonld :release_sentinel
-;  [msg]
-;  (let [content (:content msg)
-;        iri (str iri/release-sentinel (:release_date msg))]
-;    [[iri :cg/clingen-release (:release_date msg)]]))
+;;(defmethod clinvar-model-to-jsonld :release_sentinel
+;;  [msg]
+;;  (let [content (:content msg)
+;;        iri (str iri/release-sentinel (:release_date msg))]
+;;    [[iri :cg/clingen-release (:release_date msg)]]))
 
-;(defmethod transform-clinvar :default
-;  [msg]
-;  ; entity_type did not match a defmethod for transform-clinvar
-;  (cond
-;    (= "release_sentinel" (get msg :type))
-;    (do (log/debug "Got release sentinel" msg)
-;        (transform-sentinel msg))
-;    :default
-;    (do (log/error (ex-info (str ::format " not known") {:cause msg}))
-;        ; Return no triples
-;        [])))
+;;(defmethod transform-clinvar :default
+;;  [msg]
+;;  ;; entity_type did not match a defmethod for transform-clinvar
+;;  (cond
+;;    (= "release_sentinel" (get msg :type))
+;;    (do (log/debug "Got release sentinel" msg)
+;;        (transform-sentinel msg))
+;;    :default
+;;    (do (log/error (ex-info (str ::format " not known") {:cause msg}))
+;;        ;; Return no triples
+;;        [])))
 
 (defn get-clinvar-format [value]
   (let [cv-format (keyword (or (get-in value [:entity_type])
@@ -42,15 +42,15 @@
   exclude-ks should be a seq of value which may be a key in m"
   [m exclude-ks]
   (select-keys m (filter
-                   ; Return true if key from m is not in keys to exclude
-                   (fn [m-key] (nil? (some #(= m-key %) exclude-ks)))
-                   (keys m))))
+                  ;; Return true if key from m is not in keys to exclude
+                  (fn [m-key] (nil? (some #(= m-key %) exclude-ks)))
+                  (keys m))))
 
 (defmethod clinvar-to-model :default [event]
   (log/debug :fn ::clinvar-to-model :dispatch :default :msg "No multimethod defined for event" :event event)
-  ; Avoids NPE on downstream interceptors expecting a model to exist
+  ;; Avoids NPE on downstream interceptors expecting a model to exist
   (l/statements-to-model [])
-  ;(assoc event ::q/model )
+  ;;(assoc event ::q/model )
   )
 
 (defmethod add-model :clinvar-raw [event]
@@ -61,9 +61,9 @@
                     (#(assoc % ::parsed-value (-> %
                                                   :genegraph.sink.event/value
                                                   (json/parse-string true))))
-                    ;((fn [event] (log/info :event event) event))
-                    ;(#(assoc % ::parsed-value (-> % ::parsed-value util/parse-nested-content)))
-                    ;((fn [event] (log/info :msg "parsed content" :parsed-value (::parsed-value event)) event))
+                    ;;((fn [event] (log/info :event event) event))
+                    ;;(#(assoc % ::parsed-value (-> % ::parsed-value util/parse-nested-content)))
+                    ;;((fn [event] (log/info :msg "parsed content" :parsed-value (::parsed-value event)) event))
                     (#(assoc % :genegraph.transform.clinvar/format (get-clinvar-format (::parsed-value %))))
                     (#(assoc % ::q/model (clinvar-to-model %))))]
       (log/debug :fn ::add-model :event event)

--- a/src/genegraph/transform/clinvar/jsonld/clinical_assertion.clj
+++ b/src/genegraph/transform/clinvar/jsonld/clinical_assertion.clj
@@ -3,7 +3,7 @@
             [genegraph.database.names :refer [local-property-names local-class-names prefix-ns-map]]
             [genegraph.database.query :as q]
             [genegraph.transform.clinvar.common :refer [transform-clinvar
-                                                        clinvar-to-jsonld
+                                                        clinvar-model-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri
                                                         vcv-review-status-to-evidence-strength-map
@@ -14,7 +14,7 @@
             [genegraph.transform.clinvar.iri :as iri]
             [genegraph.transform.clinvar.util :refer [in?]]
             [io.pedestal.log :as log]
-    ;[clojure.set :as set]
+            ;;[clojure.set :as set]
             [clojure.string :as s]))
 
 (def genes-for-variation-byversion-query "
@@ -208,7 +208,7 @@ ORDER BY ?s_variant ?gene_id"
          }
         ))))
 
-(defmethod clinvar-to-jsonld :clinical_assertion [msg]
+(defmethod clinvar-model-to-jsonld :clinical_assertion [msg]
   (clinical-assertion-to-jsonld msg))
 
 ;(defmethod transform-clinvar :clinical_assertion [msg]

--- a/src/genegraph/transform/clinvar/jsonld/gene.clj
+++ b/src/genegraph/transform/clinvar/jsonld/gene.clj
@@ -2,7 +2,7 @@
   (:require [genegraph.database.load :as l]
             [genegraph.database.query :as q]
             [genegraph.transform.clinvar.common :refer [transform-clinvar
-                                                        clinvar-to-jsonld
+                                                        clinvar-model-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri]]
             [genegraph.transform.clinvar.iri :as iri]))
@@ -36,5 +36,5 @@
         (-> msg (dissoc
                   :full_name))))))
 
-(defmethod clinvar-to-jsonld :gene [msg]
+(defmethod clinvar-model-to-jsonld :gene [msg]
   (gene-to-jsonld msg))

--- a/src/genegraph/transform/clinvar/jsonld/submission.clj
+++ b/src/genegraph/transform/clinvar/jsonld/submission.clj
@@ -3,7 +3,7 @@
             [genegraph.database.names :refer [local-property-names local-class-names prefix-ns-map]]
             [genegraph.database.query :as q]
             [genegraph.transform.clinvar.common :refer [transform-clinvar
-                                                        clinvar-to-jsonld
+                                                        clinvar-model-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri
                                                         vcv-review-status-to-evidence-strength-map
@@ -27,5 +27,5 @@
         {"@type" (str iri/cgterms "AssertionSet")}
         msg))))
 
-(defmethod clinvar-to-jsonld :submission [msg]
+(defmethod clinvar-model-to-jsonld :submission [msg]
   (submission-to-jsonld msg))

--- a/src/genegraph/transform/clinvar/jsonld/variation.clj
+++ b/src/genegraph/transform/clinvar/jsonld/variation.clj
@@ -2,7 +2,7 @@
   (:require [genegraph.database.load :as l]
             [genegraph.database.query :as q]
             [genegraph.transform.clinvar.common :refer [transform-clinvar
-                                                        clinvar-to-jsonld
+                                                        clinvar-model-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri]]
             [genegraph.transform.clinvar.iri :as iri]))
@@ -43,5 +43,5 @@
         (-> msg (dissoc :id
                         ))))))
 
-(defmethod clinvar-to-jsonld :variation [msg]
+(defmethod clinvar-model-to-jsonld :variation [msg]
   (variation-to-jsonld msg))

--- a/src/genegraph/transform/clinvar/jsonld/variation_archive.clj
+++ b/src/genegraph/transform/clinvar/jsonld/variation_archive.clj
@@ -2,7 +2,7 @@
   (:require [genegraph.database.load :as l]
             [genegraph.database.query :as q]
             [genegraph.transform.clinvar.common :refer [transform-clinvar
-                                                        clinvar-to-jsonld
+                                                        clinvar-model-to-jsonld
                                                         variation-geno-type
                                                         genegraph-kw-to-iri]]
             [genegraph.transform.clinvar.iri :as iri]))
@@ -68,5 +68,5 @@
                         )
             )))))
 
-(defmethod clinvar-to-jsonld :variation_archive [msg]
+(defmethod clinvar-model-to-jsonld :variation_archive [msg]
   (variation-archive-to-jsonld msg))

--- a/src/genegraph/transform/dosage_jira.clj
+++ b/src/genegraph/transform/dosage_jira.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.string :as s]
             [flatland.ordered.map :refer [ordered-map]]
+
             [camel-snake-kebab.core :refer :all]
             [genegraph.database.query :as q]
             [genegraph.database.load :as l]
@@ -28,7 +29,7 @@
 
 (spec/def ::resolution #(= "Complete" (:name %)))
 
-(spec/def ::fields (spec/keys :req-un [::resolutiondate 
+(spec/def ::fields (spec/keys :req-un [::resolutiondate
                                        ::status
                                        ::resolution]))
 
@@ -85,7 +86,7 @@
                           "Y" "https://www.ncbi.nlm.nih.gov/nucore/NC_000024.10"}})
 
 (def build-location {:grch38 :customfield-10532
-                     :grch37 :customfield-10160}) 
+                     :grch37 :customfield-10160})
 
 
 
@@ -132,8 +133,8 @@
     (let [[_ chr start-coord end-coord] (re-find #"(\w+):(.+)-(.+)$" loc-str)
           iri (l/blank-node)
           interval-iri (l/blank-node)
-          reference-sequence (get-in chr-to-ref 
-                                     [build 
+          reference-sequence (get-in chr-to-ref
+                                     [build
                                       (subs chr 3)])]
       [iri [[iri :rdf/type :geno/SequenceFeatureLocation]
             ;; TODO reference sequence should be a resource
@@ -184,7 +185,7 @@
 
 (defn- finding-data [curation dosage]
   (->> (get evidence-field-map dosage)
-       (map (fn [row] 
+       (map (fn [row]
          (map #(get-in curation [:fields %]) row)))
        (remove #(nil? (first %)))))
 
@@ -285,9 +286,9 @@
 
 (defn- assertion [curation dosage]
   (if (dosage-assertion-value curation dosage)
-    (conj 
+    (conj
      (if (and (= 1 dosage)
-              (= "30: Gene associated with autosomal recessive phenotype" 
+              (= "30: Gene associated with autosomal recessive phenotype"
                  (get-in curation [:fields :customfield-10165 :value])))
        (scope-assertion curation dosage)
        (evidence-strength-assertion curation dosage))
@@ -314,6 +315,3 @@
     (if (spec/invalid? (spec/conform ::fields (:fields jira-json)))
       (assoc event ::spec/invalid true)
       (assoc event ::q/model (-> jira-json gene-dosage-report l/statements-to-model)))))
-
-
-

--- a/test/genegraph/annotate_test.clj
+++ b/test/genegraph/annotate_test.clj
@@ -6,15 +6,14 @@
             [clojure.test :refer :all]
             [clojure.edn :as edn]
             [clojure.java.io :as io]
-            [clojure.string :as string])
+            [clojure.string :as string]))
 
-(use-fixtures :each mount-database-fixture)  
+(use-fixtures :each mount-database-fixture)
 
 (deftest decorate-event-with-iri
   (let [evt (-> "test_data/gene_validity_0_1094.edn" io/resource slurp edn/read-string)]
     (is (= "http://dataexchange.clinicalgenome.org/gci/proposition_03628749-51d6-437e-9816-1e32852645cf"
            (-> evt add-metadata add-model add-iri ::ann/iri)))))
-
 
 (deftest actionability-event-handling
   (let [aci-evt (-> "test_data/actionability_0_1186.edn" io/resource slurp edn/read-string)]
@@ -31,9 +30,9 @@
 
 (deftest dosage-event-shacl-validation
   (let [gene-based-dosage-data  (-> "test_data/gene_dosage_sepio_in_0_201.edn"
-                       io/resource
-                       slurp
-                       edn/read-string)
+                                    io/resource
+                                    slurp
+                                    edn/read-string)
         dosage-evt (-> gene-based-dosage-data
                        add-metadata
                        add-model
@@ -43,9 +42,9 @@
                        add-validation)]
     (is (true? (validate/did-validate? (::ann/validation dosage-evt)))))
   (let [region-based-dosage-data  (-> "test_data/gene_dosage_sepio_in_0_5534.edn"
-                       io/resource
-                       slurp
-                       edn/read-string)
+                                      io/resource
+                                      slurp
+                                      edn/read-string)
         dosage-evt (-> region-based-dosage-data
                        add-metadata
                        add-model
@@ -55,17 +54,17 @@
                        add-validation)]
     (is (true? (validate/did-validate? (::ann/validation dosage-evt)))))
   (let [invalid-dosage-data  (-> "test_data/gene_dosage_sepio_in_bad.edn"
-                       io/resource
-                       slurp
-                       edn/read-string)
+                                 io/resource
+                                 slurp
+                                 edn/read-string)
         dosage-evt (-> invalid-dosage-data add-metadata add-model add-iri add-validation)]
     (is (false? (validate/did-validate? (::ann/validation dosage-evt))))))
 
 (deftest dosage-event-subjects
   (let [dosage-data  (-> "test_data/gene_dosage_sepio_in_0_201.edn"
-                       io/resource
-                       slurp
-                       edn/read-string)
+                         io/resource
+                         slurp
+                         edn/read-string)
         dosage-evt (-> dosage-data add-metadata add-model add-iri add-subjects)
         subjects (dosage-evt ::ann/subjects)]
     (is (= 1 (count (:gene-iris subjects))))
@@ -76,9 +75,9 @@
         subjects (-> evt add-metadata add-model add-iri add-subjects ::ann/subjects)]
     (is (= 1 (count (:gene-iris subjects))))
     (is (= "https://www.ncbi.nlm.nih.gov/gene/51776" (first (:gene-iris subjects))))
-        (is (= 1 (count (:disease-iris subjects))))
+    (is (= 1 (count (:disease-iris subjects))))
     (is (= "http://purl.obolibrary.org/obo/MONDO_0054695" (first (:disease-iris subjects))))))
-    
+
 (deftest actionability-event-subjects
   (let [evt (-> "test_data/actionability_0_1186.edn" io/resource slurp edn/read-string)
         subjects (-> evt add-metadata add-model add-iri add-subjects ::ann/subjects)]
@@ -86,4 +85,3 @@
     (is (= "https://www.ncbi.nlm.nih.gov/gene/55630" (first (:gene-iris subjects))))
     (is (= 1 (count (:disease-iris subjects))))
     (is (= "http://purl.obolibrary.org/obo/MONDO_0008713" (first (:disease-iris subjects))))))
-

--- a/test/genegraph/service_test.clj
+++ b/test/genegraph/service_test.clj
@@ -16,9 +16,10 @@
                                  :body (json/generate-string {:query request :variables variables}))]
       (assoc response :json (json/parse-string (:body response) true)))))
 
+#_
 (deftest request-gating-test
   (let [schema (schema/compile
-                {:queries 
+                {:queries
                  {:hello
                   {:type 'String
                    :resolve (fn  [& _]
@@ -32,4 +33,4 @@
       (doseq [r result]
         (.start (Thread. #(deliver r (query "{hello}" {})))))
       (testing "Request gate should have one unique result"
-          (is (= 1 (->> result (map #(:body @%)) (into #{}) count)))))))
+        (is (= 1 (->> result (map #(:body @%)) (into #{}) count)))))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,7 @@
+#kaocha/v1
+{:tests [{:id           :all
+          :source-paths ["src"]
+          :test-paths   ["test"]
+          :ns-patterns  ["genegraph\\..*-test$"]}]
+
+ :plugins [:print-invocations :profiling]}


### PR DESCRIPTION
[genegraph/495](https://app.zenhub.com/workspaces/genegraphdxclinvar-60340fb9898dae001107e94e/issues/clingen-data-model/genegraph/495)

It now works on my machine.

I updated a lot of dependencies and removed most of the `:exclusions`.

I also sorted them alphabetically to emphasize that `:deps` is unordered.

I would be surprised if this does not break *some*thing, but I don't know how to test it.

```
tbl@wmf05-d86 ~/Broad/ClinVar/genegraph # clj -T:build clean
Downloading: org/apache/lucene/lucene-suggest/7.7.3/lucene-suggest-7.7.3.pom from central
... 2 lines ...
Downloading: org/apache/lucene/lucene-core/7.7.3/lucene-core-7.7.3.jar from central
tbl@wmf05-d86 ~/Broad/ClinVar/genegraph # clj -T:build uber
16:04:22,497 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
... 40 lines ...
WARNING: agent already refers to: #'clojure.core/agent in namespace: genegraph.source.graphql.schema.agent, being replaced by: #'genegraph.source.graphql.schema.agent/agent
tbl@wmf05-d86 ~/Broad/ClinVar/genegraph # java -jar ./target/genegraph.jar
WARNING: abs already refers to: #'clojure.core/abs in namespace: taoensso.encore, being replaced by: #'taoensso.encore/abs
... 340 lines ...
16:07:42.881 [main] INFO  genegraph.server  - {:fn :-main, :message "Genegraph fully initialized, all systems go", :line 83}
  C-c C-c
tbl@wmf05-d86 ~/Broad/ClinVar/genegraph 130#
```
