### PR TITLE
Disabling property store due to issues loading HPO

### DIFF
--- a/src/genegraph/database/load.clj
+++ b/src/genegraph/database/load.clj
@@ -78,7 +78,7 @@
   ([model name opts]
    (write-tx
     (.replaceNamedModel db name model)
-    (property-store/put-model! model)
+    ;; (property-store/put-model! model)
     {:succeeded true})))
 
 (defn remove-model

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -253,7 +253,7 @@
   clojure.lang.IPersistentVector
   (step [edge start model]
     (let [property (kw-to-property (first edge))]
-      (if (property-store/property-in-store? property)
+      (if false ;; (property-store/property-in-store? property)
         (property-store/get-property start property)
         (tx 
          (let [out-fn (fn [n] (->> (.listObjectsOfProperty model (.resource n) property)


### PR DESCRIPTION
Use of the property store errors on loading Human Phenotype Ontology, creating issues in production Genegraph. Since this feature never delivered the hoped for improvements in production Genegraph 