### PR TITLE
Changing the way the resolver cache expires resources

### DIFF
--- a/src/genegraph/source/graphql/common/cache.clj
+++ b/src/genegraph/source/graphql/common/cache.clj
@@ -3,7 +3,7 @@
             [genegraph.env :as env]
             [mount.core :as mount :refer [defstate]]
             [genegraph.rocksdb :as rocksdb :refer [rocks-get rocks-put! rocks-delete!]]
-            [genegraph.database.query :as q :refer [resource]]))
+            [genegraph.database.query :as q]))
 
 (defstate resolver-cache-db
   :start (rocksdb/open "graphql_resolver_cache")
@@ -44,7 +44,7 @@
                              v)
       :else (rocks-put! resolver-cache-db k v))))
 
-(defn expire-resolver-cache-on-event! [event]
+(defn- expire-resolver-cache-on-event! [event]
   (when (running?)
     (rocksdb/rocks-delete-with-prefix! resolver-cache-db ::expire-always)
     (doseq [topic (-> event ::q/model q/referenced-resources)]

--- a/src/genegraph/source/graphql/common/cache.clj
+++ b/src/genegraph/source/graphql/common/cache.clj
@@ -3,7 +3,7 @@
             [genegraph.env :as env]
             [mount.core :as mount :refer [defstate]]
             [genegraph.rocksdb :as rocksdb :refer [rocks-get rocks-put! rocks-delete!]]
-            [genegraph.database.query :refer [resource]]))
+            [genegraph.database.query :as q :refer [resource]]))
 
 (defstate resolver-cache-db
   :start (rocksdb/open "graphql_resolver_cache")
@@ -47,8 +47,8 @@
 (defn expire-resolver-cache-on-event! [event]
   (when (running?)
     (rocksdb/rocks-delete-with-prefix! resolver-cache-db ::expire-always)
-    (doseq [topic (-> event :genegraph.annotate/subjects vals flatten)]
-      (rocksdb/rocks-delete-with-prefix! resolver-cache-db (resource topic))))
+    (doseq [topic (-> event ::q/model q/referenced-resources)]
+      (rocksdb/rocks-delete-with-prefix! resolver-cache-db topic)))
   event)
 
 (def expire-resolver-cache-interceptor

--- a/src/genegraph/util/repl.clj
+++ b/src/genegraph/util/repl.clj
@@ -34,7 +34,8 @@
             [genegraph.database.property-store :as property-store])
   (:import java.time.Instant
            java.time.temporal.ChronoUnit
-           org.apache.jena.rdf.model.AnonId))
+           org.apache.jena.rdf.model.AnonId
+           org.apache.jena.rdf.model.Model))
 
 ;; (defn start-rebl []
 ;;   (rebl/ui))


### PR DESCRIPTION
Previously only cache entries tied to specific subjects
identified for inclusion in a model were expired, such as
genes and diseases. This left out cases where entities
included in the model itself are updated (such as the disease
for a gene validity curation). This code harvests all the
referenced resources in a new model and expires any references
to all of them in the resolver cache, addressing the issue.