### PR TITLE
Retrieve base data from cloud

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -77,7 +77,7 @@
   buddy/buddy-sign {:mvn/version "3.2.0"}
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.11.0"}
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.11.0"}
-  com.google.cloud/google-cloud-storage {:mvn/version "1.108.0"}
+  com.google.cloud/google-cloud-storage {:mvn/version "2.6.1"}
   ;; rocksjni for everything else -- is there an arch switch in deps?
   ;;  org.rocksdb/rocksdbjni {:mvn/version "6.25.3"}
   ;; rocksjni for apple silicon--will not work on Intel

--- a/doc/base_data.md
+++ b/doc/base_data.md
@@ -1,0 +1,24 @@
+# Base data
+(genegraph.sink.base)
+
+While the main focus of data ingest in Genegraph is through streaming sources, there is a need to incorporate one-time data from bulk sources at the beginning of every build. These sources are described in resources/base.edn. Facilities exist for downloading fresh copies of this data and uploading them to the Google Cloud. When a new build is requested, the version of files stored in current-base/ in the Genegraph cloud bucket is downloaded and incorporated into the Jena database
+
+## Fields in base.edn
+
+  * name: graph name to be used in Jena on import
+  * source: HTTP(S) or FTP source from which the file can be downloaded
+  * target: local filename for the resource
+  * format: format the file is stored in, maps to the transformer needed to load the data
+  * reader-opts: special options the transformer may need to interpret the data
+
+## Refreshing the data
+
+Specific functions are used for updating the current version of the base data in the cloud
+
+### genegraph.sink.base/retrieve-base-data! 
+
+Download all required base data from the origin to the localhost
+
+### genegraph.sink.base/push-base-data-to-gcp!
+
+Upload all local base data into the cloud

--- a/src/genegraph/sink/batch.clj
+++ b/src/genegraph/sink/batch.clj
@@ -66,4 +66,3 @@
         :compressed-event-files (process-compressed-event-file! descriptor)
         :json-event-sequence (process-json-event-sequence! descriptor)))))
 
-

--- a/src/genegraph/util/gcs.clj
+++ b/src/genegraph/util/gcs.clj
@@ -1,6 +1,7 @@
 (ns genegraph.util.gcs
   (:require [genegraph.env :as env]
-            [me.raynes.fs :as fs])
+            [clojure.java.io :as io]
+            [io.pedestal.log :as log])
   (:import [java.time ZonedDateTime ZoneOffset]
            java.time.format.DateTimeFormatter
            [java.nio ByteBuffer]
@@ -12,23 +13,69 @@
            [com.google.cloud.storage Storage$BlobWriteOption
             Storage$BlobTargetOption
             Storage$BlobSourceOption
+            Storage$BlobListOption
             Blob$BlobSourceOption]))
+
+(defn- storage []
+  (.getService (StorageOptions/getDefaultInstance)))
 
 (defn put-file-in-bucket!
   ([source-file blob-name]
    (put-file-in-bucket! source-file blob-name {:content-type "application/gzip"}))
   ([source-file blob-name options]
-   (let [gc-storage (.getService (StorageOptions/getDefaultInstance))
-         blob-id (BlobId/of env/genegraph-bucket blob-name)
+   (let [blob-id (BlobId/of env/genegraph-bucket blob-name)
          blob-info (-> blob-id BlobInfo/newBuilder (.setContentType (:content-type options)) .build)
          from (.getChannel (FileInputStream. source-file))]
-     (with-open [to (.writer gc-storage blob-info (make-array Storage$BlobWriteOption 0))]
+     (with-open [to (.writer (storage) blob-info (make-array Storage$BlobWriteOption 0))]
        (ByteStreams/copy from to)))))
 
 (defn get-file-from-bucket!
   [source-blob target-file]
   (let [target-path (Paths/get target-file
                                (make-array java.lang.String 0))
-        blob (.get (.getService (StorageOptions/getDefaultInstance))
+        blob (.get (storage)
                    (BlobId/of env/genegraph-bucket source-blob))]
     (.downloadTo blob target-path)))
+
+(defn list-items-in-bucket
+  ([] (list-items-in-bucket nil))
+  ([prefix]
+   (let [options (if prefix
+                   (into-array [(Storage$BlobListOption/prefix prefix)])
+                   (make-array Storage$BlobListOption 0))]
+     (-> (.list (storage)
+                env/genegraph-bucket
+                options)
+         .iterateAll
+         .iterator
+         iterator-seq))))
+
+(defn ensure-target-directory-exists!
+  "Create directory at PATH if it does not already exist.
+  Return false if directory cannot be created or already
+  exists as something other than a directory."
+  [path]
+  (let [dir (io/file path)]
+    (if (and (.exists dir) (.isDirectory dir))
+      true
+      (.mkdir dir))))
+
+(defn get-files-with-prefix!
+  "Store all files in bucket matching PREFIX to TARGET-DIR"
+  [prefix target-dir]
+  (if (ensure-target-directory-exists! target-dir)
+    (doseq [blob (list-items-in-bucket prefix)]
+      (let [target-path (Paths/get (str target-dir
+                                        (re-find #"/.*$" (.getName blob)))
+                                   (make-array java.lang.String 0))]
+        (.downloadTo blob target-path)))
+    (log/error :fn ::get-files-with-prefix!
+               :msg "Could not create directory"
+               :path target-dir)))
+
+(defn push-directory-to-bucket!
+  "Copy all files from SOURCE-DIR to TARGET-DIR in bucket."
+  [source-dir target-dir]
+  (let [dir (io/file source-dir)]
+    (doseq [file (.listFiles dir)]
+      (put-file-in-bucket! file (str target-dir "/" (.getName file))))))


### PR DESCRIPTION
Changing the way migrations happen somewhat--rather than downloading base files fresh every time, pull from GCP instead. Added a couple helper functions to assist with maintaining these files in the cloud.