### PR TITLE
Add proband score cap

### DIFF
--- a/src/genegraph/event_analyzer.clj
+++ b/src/genegraph/event_analyzer.clj
@@ -47,6 +47,13 @@
     (::q/model event)
     (-> event transform/add-model ::q/model))))
 
+(defn model-sizes
+  "return the size of the existing model in triples, as
+   well as the current transformation."
+  [event]
+  {:previous (.size (::q/model event))
+   :current (-> event transform/add-model ::q/model .size)})
+
 (defn statistics
   "Summary statistics of event processing over the topic."
   [topic]

--- a/src/genegraph/event_analyzer.clj
+++ b/src/genegraph/event_analyzer.clj
@@ -7,6 +7,9 @@
             [genegraph.transform.core :as transform]
             [clojure.data :as data]))
 
+(defn add-new-model [event]
+  (when-not (::new-model event)
+    (assoc event ::new-model (transform/add-model (::q/model event)))))
 
 (defn resource-type-counts [event]
   (->> (q/select "select ?type where { ?x a ?type }" {} (::q/model event))
@@ -54,3 +57,10 @@
        frequencies))
 
 
+(comment
+  (->> (event-recorder/events-for-topic :gene-validity-raw)
+       (take-last 10)
+       (pmap #(assoc % ::model-changed (event-analyzer/model-changed? %)))
+       (filter ::model-changed)
+       (map event-analyzer/resource-type-diff))
+  )

--- a/src/genegraph/transform/gene_validity_refactor.clj
+++ b/src/genegraph/transform/gene_validity_refactor.clj
@@ -48,6 +48,7 @@
                construct-earliest-articles
                construct-secondary-contributions
                construct-variant-score
+               construct-ar-variant-score
                construct-unscoreable-evidence)
 
 ;; Trim trailing }, intended to be appended to gci json
@@ -289,6 +290,7 @@
                         (construct-earliest-articles params)
                         (construct-secondary-contributions params)
                         (construct-variant-score params)
+                        ;; (construct-ar-variant-score params)
                         (construct-unscoreable-evidence params)
                         )]
     (q/union unlinked-model

--- a/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_score.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_score.sparql
@@ -1,0 +1,37 @@
+# Needed for composing variants in autosomal recessive
+# SOP v8 and above. These scores reflect a cap of 3
+# points per proband that needs to be represented as
+# a distinct evidence line
+
+
+# TODO pick up here. should calculate the proband score based on some combination of the variant scores. Ideally can keep remaining code from variant scores
+
+# Will need to configure evidence line connections appropriately afterwards
+
+
+prefix gci: <http://dataexchange.clinicalgenome.org/gci/>
+prefix gcixform: <http://dataexchange.clinicalgenome.org/gcixform/>
+construct {
+  ?probandScoreEvidenceLine a :sepio/ProbandEvidenceLine ;
+  :sepio/has-evidence ?variantEvidenceLine .
+  
+  ?variantEvidenceLine a ?evidenceLineType .
+} where {
+  ?variantEvidenceLine a gci:variantScore ;
+  gci:variantType ?variantType .
+
+  ?variantType gcixform:hasEvidenceLineType ?evidenceLineType ;
+  gcixform:hasEvidenceItemType ?evidenceItemType .
+  
+  ?individual gci:variantScores ?variantEvidenceLine .
+
+  # Need to construct evidence line for individual
+  BIND(IRI(CONCAT(STR(?individual), "_proband_score_evidence_line")) AS ?probandScoreEvidenceLine ) .
+
+  # Limit results to autosomal recessive MOI
+  ?gdm a gci:gdm ;
+  gci:modeInheritance ?moistr .
+
+  FILTER regex(?moistr, "0000007") .
+}
+

--- a/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_score.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_ar_variant_score.sparql
@@ -8,21 +8,13 @@
 
 # Will need to configure evidence line connections appropriately afterwards
 
-
 prefix gci: <http://dataexchange.clinicalgenome.org/gci/>
 prefix gcixform: <http://dataexchange.clinicalgenome.org/gcixform/>
 construct {
   ?probandScoreEvidenceLine a :sepio/ProbandEvidenceLine ;
-  :sepio/has-evidence ?variantEvidenceLine .
-  
-  ?variantEvidenceLine a ?evidenceLineType .
+  :sepio/has-evidence ?individual , ?variantEvidenceLine .
 } where {
-  ?variantEvidenceLine a gci:variantScore ;
-  gci:variantType ?variantType .
 
-  ?variantType gcixform:hasEvidenceLineType ?evidenceLineType ;
-  gcixform:hasEvidenceItemType ?evidenceItemType .
-  
   ?individual gci:variantScores ?variantEvidenceLine .
 
   # Need to construct evidence line for individual

--- a/src/genegraph/transform/gene_validity_refactor/construct_variant_score.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_variant_score.sparql
@@ -2,7 +2,7 @@
 prefix gci: <http://dataexchange.clinicalgenome.org/gci/>
 prefix gcixform: <http://dataexchange.clinicalgenome.org/gcixform/>
 construct {
-  ?probandScoreEvidenceLine a ?evidenceLineType ;
+  ?evidenceLine a ?evidenceLineType ;
   :sepio/evidence-line-strength-score ?score ;
   :sepio/has-evidence ?evidenceItem , ?functionEvidenceItem ; # evidence about variant
   :sepio/calculated-score ?resultCalculatedScore ;
@@ -52,7 +52,9 @@ where {
   gci:calculatedScore ?calculatedScore ;
   gci:date_created ?date_created .
 
-  BIND (IRI(CONCAT(str(?evidenceLine), "_proband_score_evidence_line")) AS ?probandScoreEvidenceLine) 
+  # This is not actually a proband score, but rather a variant score
+  # Should name it as such =tristan
+  # BIND (IRI(CONCAT(str(?evidenceLine), "_proband_score_evidence_line")) AS ?probandScoreEvidenceLine) 
 
   BIND(IF(?deNovo = "Yes", :geno/DeNovoAlleleOrigin , IF(?deNovo = "No", :geno/GermlineAlleleOrigin , :geno/AlleleOrigin ) ) AS ?alleleOrigin) .
 
@@ -146,5 +148,18 @@ where {
 
   ?publication gci:pmid ?pmid .
   BIND(IRI(CONCAT(?pmbase, ?pmid)) AS ?article) .
+
+  # TODO remove this before commit 
+
+  # Bind a proband score if MOI is AR. Needed because there is a cap on the proband score
+  # in case of autosomal recessive inheritance. 
+
+  # ?gdm a gci:gdm ;
+  # gci:modeInheritance ?moistr .
+
+  # BIND(IF(REGEX(?moistr, "0000007"),
+  # 	  IRI(CONCAT(STR(?individual), "_proband_evidence_line")),
+  # 	  ?undefined)
+  #      AS ?proband_evidence_line) .p
   
 }

--- a/src/genegraph/transform/gene_validity_refactor/gdm_sepio_relationships.ttl
+++ b/src/genegraph/transform/gene_validity_refactor/gdm_sepio_relationships.ttl
@@ -121,7 +121,7 @@ sepio:0004012 :hasEvidenceLineType sepio:0000247 .
 sepio:0004002 :hasEvidenceLineType sepio:0004127 .
 
 # :sepio/OverallGeneticEvidenceEvidenceLine
-sepio:0004005 :hasEvidenceLineType sepio:0004120, sepio:0004121 .
+sepio:0004005 :hasEvidenceLineType sepio:0004120, sepio:0004121 , sepio:0004097 .
 
 # :sepio/AutosomalDominantOtherVariantCriterionAssessment
 sepio:0004011 :hasEvidenceLineType sepio:0004080 .

--- a/src/genegraph/transform/gene_validity_refactor/unlink_variant_scores_when_proband_scores_exist.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/unlink_variant_scores_when_proband_scores_exist.sparql
@@ -1,0 +1,14 @@
+construct {
+  ?s ?p ?o .
+}
+where
+{
+  ?s ?p ?o .
+  minus {
+    ?s a :sepio/OverallGeneticEvidenceLine .
+    [] :sepio/has-evidence ?o ;
+    a :sepio/ProbandEvidenceLine .
+    { ?o a :sepio/NullVariantEvidenceLine . } union
+    { ?o a :sepio/NonNullVariantEvidenceLine . }
+  }
+}


### PR DESCRIPTION
Added a new evidence line for SOPv8+ curations (with scored variants) and Autosomal Recessive inheritance. This is added to represent the cap of 3 points per proband that needs to be represented in the data.

Resolves #526 