### PR TITLE
Add pretty-print for model objects

### DIFF
--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -173,3 +173,20 @@ use io/slurp"
   "Return true if MODEL-ONE is isomorphic relative to MODEL-TWO"
   [model-one model-two]
   (.isIsomorphicWith model-one model-two))
+
+(defn pp-model
+  "Print a turtle-like string of model, with iri values
+  substituted for local keywords when available."
+  [model]
+  (let [statements (iterator-seq (.listStatements model))
+        predicate-iri-kw (map #(vector % (names/property-uri->keyword %))
+                              (set (map #(.getPredicate %) statements)))
+        object-iri-kw (map #(vector % (names/class-uri->keyword %))
+                           (set (map #(.getObject %) statements)))]
+    (println
+     (reduce (fn [model-str [iri kw]]
+               (s/replace model-str (str "<" iri ">")
+                          (str kw)))
+             (to-turtle model)
+             (filter second ; remove when no mapping exists
+                     (concat predicate-iri-kw object-iri-kw))))))

--- a/src/genegraph/database/query.clj
+++ b/src/genegraph/database/query.clj
@@ -185,7 +185,8 @@ use io/slurp"
                            (set (map #(.getObject %) statements)))]
     (println
      (reduce (fn [model-str [iri kw]]
-               (s/replace model-str (str "<" iri ">")
+               (s/replace model-str
+                          (str "<" iri ">")
                           (str kw)))
              (to-turtle model)
              (filter second ; remove when no mapping exists


### PR DESCRIPTION
Adding everyone for review as this might be somewhat useful for folks; wanted to make us aware of this.

When editing a model, printing the turtle output to check one's work is usually a reasonable thing to do, but it usually winds up emitting a lot of serialized IRI strings that are hard to read (http://purl.obolibrary.org/obo/SEPIO_0004001, for instance...) This just substitutes the local keyword for those when they're observed (at least in the predicate or object position), making for a much more readable output.

As an example, here's a dosage curation put through the pretty-printer:

```
<http://dx.clinicalgenome.org/entities/ISCA-4554x1>
        a       :sepio/DosageSensitivityProposition ;
        :sepio/has-subject
                [ a       :geno/FunctionalCopyNumberComplement ;
                  :geno/has-location
                          <https://www.ncbi.nlm.nih.gov/gene/331> ;
                  :geno/has-member-count
                          "1"^^<http://www.w3.org/2001/XMLSchema#long>
                ] ;
        :sepio/has-predicate
                :geno/PathogenicForCondition ;
        :sepio/has-object
                <http://purl.obolibrary.org/obo/MONDO_0010385> .

<http://dx.clinicalgenome.org/entities/ISCA-4554x1-2022-06-01T17:30:34Z>
        a       :sepio/EvidenceLevelAssertion ;
        :sepio/is-specified-by
                :sepio/DosageSensitivityEvaluationGuideline ;
        :sepio/qualified-contribution
                <http://dx.clinicalgenome.org/entities/contribution-ISCA-4554-2022-06-01T17:30:34Z> ;
        :sepio/has-subject
                <http://dx.clinicalgenome.org/entities/ISCA-4554x1> ;
        :sepio/has-predicate
                :sepio/HasEvidenceLevel ;
        :sepio/has-object
                :sepio/DosageSufficientEvidence ;
        :dc/description
                "" .

<http://dx.clinicalgenome.org/entities/ISCA-4554-2022-06-01T17:30:34Z>
        a       :sepio/GeneDosageReport ;
        :bfo/has-part
                <http://dx.clinicalgenome.org/entities/ISCA-4554x1-2022-06-01T17:30:34Z> , <http://dx.clinicalgenome.org/entities/ISCA-4554x3-2022-06-01T17:30:34Z> ;
        :iao/is-about
                <https://www.ncbi.nlm.nih.gov/gene/331> ;
        :sepio/qualified-contribution
                <http://dx.clinicalgenome.org/entities/contribution-ISCA-4554-2022-06-01T17:30:34Z> ;
        :dc/is-version-of
                <http://dx.clinicalgenome.org/entities/ISCA-4554> .

<http://dx.clinicalgenome.org/entities/ISCA-4554x3-2022-06-01T17:30:34Z>
        a       :sepio/EvidenceLevelAssertion ;
        :sepio/is-specified-by
                :sepio/DosageSensitivityEvaluationGuideline ;
        :sepio/qualified-contribution
                <http://dx.clinicalgenome.org/entities/contribution-ISCA-4554-2022-06-01T17:30:34Z> ;
        :sepio/has-subject
                <http://dx.clinicalgenome.org/entities/ISCA-4554x3> ;
        :sepio/has-predicate
                :sepio/HasEvidenceLevel ;
        :sepio/has-object
                :sepio/DosageNoEvidence ;
        :dc/description
                "" .

<http://dx.clinicalgenome.org/entities/contribution-ISCA-4554-2022-06-01T17:30:34Z>
        :bfo/realizes
                :sepio/InterpreterRole ;
        :sepio/activity-date
                "2012-07-06T20:48:54Z" .

<http://dx.clinicalgenome.org/entities/ISCA-4554>
        a       :sepio/GeneDosageRecord .

<http://dx.clinicalgenome.org/entities/ISCA-4554x3>
        a       :sepio/DosageSensitivityProposition ;
        :sepio/has-subject
                [ a       :geno/FunctionalCopyNumberComplement ;
                  :geno/has-location
                          <https://www.ncbi.nlm.nih.gov/gene/331> ;
                  :geno/has-member-count
                          "3"^^<http://www.w3.org/2001/XMLSchema#long>
                ] ;
        :sepio/has-predicate
                :geno/PathogenicForCondition ;
        :sepio/has-object
                :mondo/Disease .
```