### PR TITLE
520: Test CNV string parser.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -57,6 +57,7 @@
  {org.clojure/clojure                               {:mvn/version "1.11.1"}
   org.clojure/core.async                            {:mvn/version "1.5.648"}
   org.clojure/data.csv                              {:mvn/version "1.0.1"}
+  org.clojure/test.check                            {:mvn/version "1.1.1"}
   camel-snake-kebab/camel-snake-kebab               {:mvn/version "0.4.2"}
   ch.qos.logback/logback-classic                    {:mvn/version "1.2.11"}
   ;; Why not just clojure.data.json? =tbl

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -4,7 +4,6 @@
             [clojure.string     :as str]))
 
 (s/def ::string               (s/and string? seq))
-(s/def ::accession            ::string)
 (s/def ::assembly             ::string)
 (s/def ::chr                  ::string)
 (s/def ::cytogenetic-location ::string)
@@ -74,8 +73,6 @@
 (def ^:private project
   "Project the fields of a CNV map into a sequence."
   (apply juxt (rest field-keys)))
-
-;; parse and unparse do not support ::cnv-accession yet.
 
 (s/fdef parse
   :args (s/cat :s ::string)

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -21,6 +21,14 @@
                                        ::start
                                        ::total_copies]))
 
+(s/fdef parse
+  :args ::string
+  :ret  ::cnv)
+
+(s/fdef unparse
+  :args ::cnv
+  :ret  ::string)
+
 (def ^:private the-counts
   "These fields have integer values."
   [:start :end :total_copies])
@@ -74,20 +82,12 @@
   "Project the fields of a CNV map into a sequence."
   (apply juxt (rest field-keys)))
 
-(s/fdef parse
-  :args ::string
-  :ret  ::cnv)
-
 (defn parse
   "Nil or the CNV string S parsed into a map."
   [s]
   (let [result (some-> s raw-parse longify-the-counts)]
     (when (s/valid? ::cnv result)
       result)))
-
-(s/fdef unparse
-  :args ::cnv
-  :ret  ::string)
 
 (defn unparse
   "Return the string representation of the CNV map."

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -84,12 +84,12 @@
 ;; parse and unparse do not support ::cnv-accession yet.
 
 (s/fdef parse
-  :args ::string
+  :args (s/cat :s ::string)
   :ret  (s/or :bad nil?
               :ok  ::cnv-chr))
 
 (s/fdef unparse
-  :args ::cnv-chr
+  :args (s/cat :cnv ::cnv-chr)
   :ret  ::string)
 
 (defn parse

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -13,20 +13,14 @@
 (s/def ::start                nat-int?)
 (s/def ::total_copies         nat-int?)
 
-;; A parsed CNV has either :accession or :assembly and :chr.
-;;
-(s/def ::cnv-base             (s/keys :opt    [::cytogenetic-location
-                                               ::reference
-                                               ::string]
-                                      :req-un [::end
+(s/def ::cnv                  (s/keys :opt    [::string]
+                                      :req    [::cytogenetic-location
+                                               ::reference]
+                                      :req-un [::assembly
+                                               ::chr
+                                               ::end
                                                ::start
                                                ::total_copies]))
-(s/def ::cnv-accession        (s/and ::cnv-base
-                                     (s/keys  :req-un [::accession])))
-(s/def ::cnv-chr              (s/and ::cnv-base
-                                     (s/keys  :req-un [::assembly ::chr])))
-(s/def ::cnv                  (s/or  :accession ::cnv-accession
-                                     :chr       ::cnv-chr))
 
 (def ^:private the-counts
   "These fields have integer values."
@@ -34,11 +28,11 @@
 
 (def ^:private regular-expressions
   "Order the parsed result keys and their regular expression strings."
-  (concat [:assembly            "([^\\p{Blank}/]+)"
-           ::reference          "([^\\p{Blank}/]*)"
-           ::cytogenic-location "([^\\p{Blank}()]*)"
-           :chr                 "([^\\p{Blank}:]+)"]
-          (interleave the-counts (repeat "(\\d+)"))))
+  (concat [:assembly              "([^\\p{Blank}/]+)"
+           ::reference            "([^\\p{Blank}/]*)"
+           ::cytogenetic-location "([^\\p{Blank}()]*)"
+           :chr                   "([^\\p{Blank}:]+)"]
+          (interleave the-counts  (repeat "(\\d+)"))))
 
 (def ^:private unparse-template
   "The basic syntax of CNV strings."
@@ -86,17 +80,17 @@
 (s/fdef parse
   :args (s/cat :s ::string)
   :ret  (s/or :bad nil?
-              :ok  ::cnv-chr))
+              :ok  ::cnv))
 
 (s/fdef unparse
-  :args (s/cat :cnv ::cnv-chr)
+  :args (s/cat :cnv ::cnv)
   :ret  ::string)
 
 (defn parse
   "Nil or the CNV string S parsed into a map."
   [s]
   (let [result (some-> s raw-parse longify-the-counts)]
-    (when (s/valid? ::cnv-chr result)
+    (when (s/valid? ::cnv result)
       result)))
 
 (defn unparse

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -3,27 +3,29 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string     :as str]))
 
-(s/def ::string       (s/and string? seq))
-(s/def ::accession    ::string)
-(s/def ::assembly     ::string)
-(s/def ::chr          ::string)
-(s/def ::end          nat-int?)
-(s/def ::reference    ::string)
-(s/def ::start        nat-int?)
-(s/def ::total_copies nat-int?)
-(s/def ::cnv          (s/keys :opt    [::cytogenetic-location
-                                       ::reference
-                                       ::string]
-                              :opt-un [::accession]
-                              :req-un [::assembly
-                                       ::chr
-                                       ::end
-                                       ::start
-                                       ::total_copies]))
+(s/def ::string               (s/and string? seq))
+(s/def ::accession            ::string)
+(s/def ::assembly             ::string)
+(s/def ::chr                  ::string)
+(s/def ::cytogenetic-location ::string)
+(s/def ::end                  nat-int?)
+(s/def ::reference            ::string)
+(s/def ::start                nat-int?)
+(s/def ::total_copies         nat-int?)
+(s/def ::cnv                  (s/keys :opt    [::cytogenetic-location
+                                               ::reference
+                                               ::string]
+                                      :opt-un [::accession]
+                                      :req-un [::assembly
+                                               ::chr
+                                               ::end
+                                               ::start
+                                               ::total_copies]))
 
 (s/fdef parse
   :args ::string
-  :ret  ::cnv)
+  :ret  (s/or :bad  nil?
+              :good ::cnv))
 
 (s/fdef unparse
   :args ::cnv

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -12,9 +12,9 @@
 (s/def ::start        nat-int?)
 (s/def ::total_copies nat-int?)
 (s/def ::cnv          (s/keys :opt    [::cytogenetic-location
-                                       ::reference]
+                                       ::reference
+                                       ::string]
                               :opt-un [::accession]
-                              :req    [::string]
                               :req-un [::assembly
                                        ::chr
                                        ::end

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -27,10 +27,10 @@
 
 (def ^:private regular-expressions
   "Order the parsed result keys and their regular expression strings."
-  (concat [:assembly            "([^ /]+)"
-           ::reference          "([^ /]*)"
-           ::cytogenic-location "([^()]*)"
-           :chr                 "([^:]+)"]
+  (concat [:assembly            "([^\\p{Blank}/]+)"
+           ::reference          "([^\\p{Blank}/]*)"
+           ::cytogenic-location "([^\\p{Blank}()]*)"
+           :chr                 "([^\\p{Blank}:]+)"]
           (interleave the-counts (repeat "(\\d+)"))))
 
 (def ^:private unparse-template

--- a/src/genegraph/annotate/cnv.clj
+++ b/src/genegraph/annotate/cnv.clj
@@ -74,38 +74,22 @@
   "Project the fields of a CNV map into a sequence."
   (apply juxt (rest field-keys)))
 
+(s/fdef parse
+  :args ::string
+  :ret  ::cnv)
+
 (defn parse
   "Nil or the CNV string S parsed into a map."
   [s]
-  {:pre [(string? s)]}
   (let [result (some-> s raw-parse longify-the-counts)]
     (when (s/valid? ::cnv result)
       result)))
 
+(s/fdef unparse
+  :args ::cnv
+  :ret  ::string)
+
 (defn unparse
   "Return the string representation of the CNV map."
   [cnv]
-  {:pre [(s/valid? ::cnv cnv)]}
   (apply format unparse-template (project cnv)))
-
-(comment
-  (def examples ["GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
-                 "GRCh38/hg38 1p36.33(chr1:1029317-1072906)x4"
-                 "GRCh37/hg19 Yp11.32(chrY:21267-39498)x0"
-                 "NCBI36/hg18 Xq21.31(chrX:88399122-88520760)x1"
-                 "GRCh37/hg19 Xp22.33(chrX:697169-1238257)x0"
-                 "GRCh37/hg19 13q31.3(chr13:93244802-93269486)x0"
-                 "GRCh38/hg38 6q16.1-16.2(chr6:98770647-99813111)x1"])
-  (assert (= examples (mapv (comp unparse parse) examples)))
-  "For example ..."
-  (s/valid? ::cnv
-            {::cytogenetic-location "1q21.1"
-             ::reference "hg19"
-             ::string "GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
-             ::variation-id 145208
-             :assembly "GRCh37"
-             :chr "1"
-             :end 143284670
-             :start 143134063
-             :total_copies 3})
-  (s/valid? ::cnv nil))

--- a/test/genegraph/annotate/cnv_test.clj
+++ b/test/genegraph/annotate/cnv_test.clj
@@ -1,0 +1,28 @@
+(ns genegraph.annotate.cnv_test
+  "Test copy number variation parsing."
+  (:require [clojure.spec.alpha :as s]
+            [genegraph.annotate.cnv :as cnv]))
+
+(def examples
+  "Examples of CNV string syntax."
+  ["GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
+   "GRCh38/hg38 1p36.33(chr1:1029317-1072906)x4"
+   "GRCh37/hg19 Yp11.32(chrY:21267-39498)x0"
+   "NCBI36/hg18 Xq21.31(chrX:88399122-88520760)x1"
+   "GRCh37/hg19 Xp22.33(chrX:697169-1238257)x0"
+   "GRCh37/hg19 13q31.3(chr13:93244802-93269486)x0"
+   "GRCh38/hg38 6q16.1-16.2(chr6:98770647-99813111)x1"])
+
+(assert (= examples (mapv (comp cnv/unparse cnv/parse) examples)))
+
+(s/valid? ::cnv/cnv
+          {::cnv/cytogenetic-location "1q21.1"
+           ::cnv/reference "hg19"
+           ::cnv/string "GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
+           ::cnv/variation-id 145208
+           :assembly "GRCh37"
+           :chr "1"
+           :end 143284670
+           :start 143134063
+           :total_copies 3})
+(s/valid? ::cnv/cnv nil)

--- a/test/genegraph/annotate/cnv_test.clj
+++ b/test/genegraph/annotate/cnv_test.clj
@@ -29,5 +29,3 @@
              (every? true?))))
   (testing "nil is not a ::cnv"
     (is (not (s/valid? ::cnv/cnv nil)))))
-
-(comment (clojure.test/test-all-vars *ns*))

--- a/test/genegraph/annotate/cnv_test.clj
+++ b/test/genegraph/annotate/cnv_test.clj
@@ -15,6 +15,9 @@
    "GRCh38/hg38 6q16.1-16.2(chr6:98770647-99813111)x1"
    "NCBI36/hg18 Xq21.31(chrX:88399122-88520760)x1"])
 
+(st/instrument `cnv/parse)
+(st/instrument `cnv/unparse)
+
 (deftest satisfy-examples
   (testing "round-trip all the example strings"
     (is (= examples (map (comp cnv/unparse cnv/parse) examples)))))
@@ -26,3 +29,5 @@
              (every? true?))))
   (testing "nil is not a ::cnv"
     (is (not (s/valid? ::cnv/cnv nil)))))
+
+(comment (clojure.test/test-all-vars *ns*))

--- a/test/genegraph/annotate/cnv_test.clj
+++ b/test/genegraph/annotate/cnv_test.clj
@@ -1,28 +1,28 @@
 (ns genegraph.annotate.cnv_test
   "Test copy number variation parsing."
-  (:require [clojure.spec.alpha :as s]
-            [genegraph.annotate.cnv :as cnv]))
+  (:require [clojure.test            :refer [is deftest testing]]
+            [clojure.spec.alpha      :as s]
+            [clojure.spec.test.alpha :as st]
+            [genegraph.annotate.cnv  :as cnv]))
 
-(def examples
+(def ^:private examples
   "Examples of CNV string syntax."
-  ["GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
-   "GRCh38/hg38 1p36.33(chr1:1029317-1072906)x4"
-   "GRCh37/hg19 Yp11.32(chrY:21267-39498)x0"
-   "NCBI36/hg18 Xq21.31(chrX:88399122-88520760)x1"
+  ["GRCh37/hg19 13q31.3(chr13:93244802-93269486)x0"
+   "GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
    "GRCh37/hg19 Xp22.33(chrX:697169-1238257)x0"
-   "GRCh37/hg19 13q31.3(chr13:93244802-93269486)x0"
-   "GRCh38/hg38 6q16.1-16.2(chr6:98770647-99813111)x1"])
+   "GRCh37/hg19 Yp11.32(chrY:21267-39498)x0"
+   "GRCh38/hg38 1p36.33(chr1:1029317-1072906)x4"
+   "GRCh38/hg38 6q16.1-16.2(chr6:98770647-99813111)x1"
+   "NCBI36/hg18 Xq21.31(chrX:88399122-88520760)x1"])
 
-(assert (= examples (mapv (comp cnv/unparse cnv/parse) examples)))
+(deftest satisfy-examples
+  (testing "round-trip all the example strings"
+    (is (= examples (map (comp cnv/unparse cnv/parse) examples)))))
 
-(s/valid? ::cnv/cnv
-          {::cnv/cytogenetic-location "1q21.1"
-           ::cnv/reference "hg19"
-           ::cnv/string "GRCh37/hg19 1q21.1(chr1:143134063-143284670)x3"
-           ::cnv/variation-id 145208
-           :assembly "GRCh37"
-           :chr "1"
-           :end 143284670
-           :start 143134063
-           :total_copies 3})
-(s/valid? ::cnv/cnv nil)
+(deftest output-spec
+  (testing "the ::cnv spec is correct."
+    (is (->> examples
+             (map (comp (partial s/valid? ::cnv/cnv) cnv/parse))
+             (every? true?))))
+  (testing "nil is not a ::cnv"
+    (is (not (s/valid? ::cnv/cnv nil)))))


### PR DESCRIPTION
Follow up
https://app.zenhub.com/workspaces/genegraphdxclinvar-60340fb9898dae001107e94e/issues/clingen-data-model/genegraph/520
with an automated test and try out some spec-based property testing.
Will probably remove the `:accession` support to make input generation easier.

I removed the `:accession` support for now.
We should probably make `cytogenetic-location` and `reference` unqualified keywords,
because they are both required to reconstitute a CNV string.