### PR TITLE
Adding field to hide nested variant el when needed

### DIFF
--- a/src/genegraph/source/graphql/schema/common.clj
+++ b/src/genegraph/source/graphql/schema/common.clj
@@ -14,11 +14,25 @@
     ?statement :sepio/has-evidence ?evidence .
     ?evidence ( a / :rdfs/sub-class-of * ) ?class }"))
 
+;; Technical debt adopted to meet a specific use case for
+;; the website and Phil. Would like to transition the site away from
+;; using this, will remove this if and when that is possible.
+(defn- has-proband-score-cap [resource]
+  (some #(= (q/resource :sepio/ProbandScoreCapEvidenceLine) %)
+        (q/ld-> resource [[:sepio/has-evidence :<] :rdf/type])))
+
+(defn- hide-nested-variant-evidence [resources]
+  (remove has-proband-score-cap resources))
+
 (defn evidence-items [_ args value]
-  (cond
-    (and (:transitive args) (:class args))
-    (transitive-evidence {:statement value
-                          :class (q/resource (:class args))})
-    (:transitive args)
-    (transitive-evidence {:statement value})
-    :else (:sepio/has-evidence value)))
+  (let [result
+        (cond
+          (and (:transitive args) (:class args))
+          (transitive-evidence {:statement value
+                                :class (q/resource (:class args))})
+          (:transitive args)
+          (transitive-evidence {:statement value})
+          :else (:sepio/has-evidence value))]
+    (if (:hide_nested_variant_evidence args)
+      (hide-nested-variant-evidence result)
+      result)))

--- a/src/genegraph/source/graphql/schema/statement.clj
+++ b/src/genegraph/source/graphql/schema/statement.clj
@@ -38,8 +38,17 @@
                             :path [:sepio/qualified-contribution]}
             :evidence {:type '(list :Resource)
                        :description "Evidence used in in support of the statement"
-                       :args {:class {:type 'String}
-                              :transitive {:type 'Boolean}}
+                       :args {:class
+                              {:type 'String
+                               :description "Filter list for instances of class, expects a curie, will use sub-class relationships."}
+                              :transitive
+                              {:type 'Boolean
+                               :description "Traverse nested evidence relationships to find all evidence from root structure satisfying constrants."}
+                              :hide_nested_variant_evidence
+                              {:type 'Boolean
+                               :description "When a variant evidence line is contained in a proband score cap evidence line, do not return the variant evidence line as a part of this result.
+
+This field is offered to satsify a very specific use case for the ClinGen website. It is recommended to avoid using it otherwise."}}
                        :resolve common/evidence-items}
             :earliest_articles {:type '(list :Resource)
                                 :description "Earlist articles reported for this statement"


### PR DESCRIPTION
I think this is necessary to continue with the current query strategy,
but would like to transition away from using this approach in the
future. At this point we are willing to take on a bit of technical
debt to get the gene validity feature over the line.