### PR TITLE
Adding logic to detect SOPv6

### DIFF
--- a/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
+++ b/src/genegraph/transform/gene_validity_refactor/construct_evidence_level_assertion.sparql
@@ -56,7 +56,15 @@ where {
     ?classification gci:sopVersion ?declaredSopVersion .
   }
 
-  BIND(COALESCE(?declaredSopVersion, <http://purl.obolibrary.org/obo/SEPIO_0004093>) AS ?sopVersion) .
+  # Per discussion with Gloria, logic to differentiate SOP v 6 and 5
+  
+  OPTIONAL {
+    ?pointsTree gci:segregation / gci:evidenceCountExome ?evidenceCountExome .
+  }
+
+  BIND(IF(bound(?evidenceCountExome), <http://purl.obolibrary.org/obo/SEPIO_0004094>, <http://purl.obolibrary.org/obo/SEPIO_0004093>) AS ?sopVerionFromStructure) .
+
+  BIND(COALESCE(?declaredSopVersion, ?sopVerionFromStructure) AS ?sopVersion) .
 
   OPTIONAL {
     ?classification gci:reasons ?reasonForChangedScore .


### PR DESCRIPTION
Relates to #633 

included logic per discussion with Gloria to differentiate SOP versions without the existence of an explicit sopVersion field.