### PR TITLE
Make builds easier to debug?

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -3,7 +3,7 @@
   (:require [clojure.pprint          :refer [pprint]]
             [clojure.tools.build.api :as b]))
 
-(def root
+(def defaults
   "The defaults to configure a build."
   {:class-dir  "target/classes"
    :main       'genegraph.server
@@ -15,8 +15,8 @@
 (defn uber
   "Throw or make an uberjar from source."
   [_]
-  (try (let [{:keys [paths] :as basis} (b/create-basis root)
-             project                   (assoc root :basis basis)]
+  (try (let [{:keys [paths] :as basis} (b/create-basis defaults)
+             project                   (assoc defaults :basis basis)]
          (b/delete      project)
          (b/copy-dir    (assoc project :src-dirs paths))
          (b/compile-clj (assoc project :src-dirs ["src"]))

--- a/build.clj
+++ b/build.clj
@@ -6,6 +6,7 @@
 (def defaults
   "The defaults to configure a build."
   {:class-dir  "target/classes"
+   :java-opts  ["-Dclojure.main.report=stderr"]
    :main       'genegraph.server
    :path       "target"
    :project    "deps.edn"

--- a/build.clj
+++ b/build.clj
@@ -1,21 +1,22 @@
 (ns build
+  "Build this thing."
   (:require [clojure.tools.build.api :as b]))
 
-(def class-dir "target/classes")
-(def basis (b/create-basis {:project "deps.edn"}))
-(def uber-file "target/genegraph.jar")
+(def root
+  "Start here."
+  {:class-dir  "target/classes"
+   :main       'genegraph.server
+   :path       "target"
+   :project    "deps.edn"
+   :target-dir "target/classes"
+   :uber-file  "target/genegraph.jar"})
 
-(defn clean [_]
-  (b/delete {:path "target"}))
-
-(defn uber [_]
-  (clean _)
-  (b/copy-dir {:src-dirs ["src" "resources" "config"]
-               :target-dir class-dir})
-  (b/compile-clj {:basis basis
-                  :src-dirs ["src"]
-                  :class-dir class-dir})
-  (b/uber {:class-dir class-dir
-           :uber-file uber-file
-           :basis basis
-           :main 'genegraph.server}))
+(defn uber
+  "Make an uberjar from source."
+  [_]
+  (let [{:keys [paths] :as basis} (b/create-basis root)
+        project                   (assoc root :basis basis)]
+    (b/delete      project)
+    (b/copy-dir    (assoc project :src-dirs paths))
+    (b/compile-clj (assoc project :src-dirs ["src"]))
+    (b/uber        project)))

--- a/build.clj
+++ b/build.clj
@@ -4,7 +4,7 @@
             [clojure.tools.build.api :as b]))
 
 (def root
-  "Start here."
+  "The defaults to configure a build."
   {:class-dir  "target/classes"
    :main       'genegraph.server
    :path       "target"
@@ -13,7 +13,7 @@
    :uber-file  "target/genegraph.jar"})
 
 (defn uber
-  "Make an uberjar from source."
+  "Throw or make an uberjar from source."
   [_]
   (try (let [{:keys [paths] :as basis} (b/create-basis root)
              project                   (assoc root :basis basis)]

--- a/build.clj
+++ b/build.clj
@@ -16,12 +16,9 @@
 (defn uber
   "Throw or make an uberjar from source."
   [_]
-  (try (let [{:keys [paths] :as basis} (b/create-basis defaults)
-             project                   (assoc defaults :basis basis)]
-         (b/delete      project)
-         (b/copy-dir    (assoc project :src-dirs paths))
-         (b/compile-clj (assoc project :src-dirs ["src"]))
-         (b/uber        project))
-       (catch Exception x
-         (pprint x)
-         (throw x))))
+  (let [{:keys [paths] :as basis} (b/create-basis defaults)
+        project                   (assoc defaults :basis basis)]
+    (b/delete      project)
+    (b/copy-dir    (assoc project :src-dirs paths))
+    (b/compile-clj (assoc project :src-dirs ["src"]))
+    (b/uber        project)))

--- a/build.clj
+++ b/build.clj
@@ -1,6 +1,7 @@
 (ns build
   "Build this thing."
-  (:require [clojure.tools.build.api :as b]))
+  (:require [clojure.pprint          :refer [pprint]]
+            [clojure.tools.build.api :as b]))
 
 (def root
   "Start here."
@@ -14,9 +15,12 @@
 (defn uber
   "Make an uberjar from source."
   [_]
-  (let [{:keys [paths] :as basis} (b/create-basis root)
-        project                   (assoc root :basis basis)]
-    (b/delete      project)
-    (b/copy-dir    (assoc project :src-dirs paths))
-    (b/compile-clj (assoc project :src-dirs ["src"]))
-    (b/uber        project)))
+  (try (let [{:keys [paths] :as basis} (b/create-basis root)
+             project                   (assoc root :basis basis)]
+         (b/delete      project)
+         (b/copy-dir    (assoc project :src-dirs paths))
+         (b/compile-clj (assoc project :src-dirs ["src"]))
+         (b/uber        project))
+       (catch Exception x
+         (pprint x)
+         (throw x))))

--- a/deps.edn
+++ b/deps.edn
@@ -13,8 +13,8 @@
  :aliases
 
  {:build                                ; clj -T:build uber
-  {:deps       {io.github.clojure/tools.build       {:tag "v0.8.1"
-                                                     :sha "7d40500"}}
+  {:deps       {io.github.clojure/tools.build       {:tag "v0.8.4"
+                                                     :sha "8c3cd69"}}
    :ns-default build}
 
   :eastwood                             ; clj -M:eastwood

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -313,3 +313,4 @@
   
   Literal
   (to-clj [x model] (.getValue x)))
+fnord

--- a/src/genegraph/database/query/types.clj
+++ b/src/genegraph/database/query/types.clj
@@ -313,4 +313,3 @@
   
   Literal
   (to-clj [x model] (.getValue x)))
-fnord


### PR DESCRIPTION
Kyle figured it out.
Some IO happens that should not be necessary for producing an uberjar.
It looks like we compile everything.  Why?