### PR TITLE
VRS caching, SCV local_key, nrepl option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY deps.edn /usr/src/app/deps.edn
 WORKDIR /usr/src/app
 RUN clojure -P
 COPY . /usr/src/app
-RUN clojure -T:build uber
+RUN clojure -T:build uber-repl
 
 # Using image without lein for deployment.
 FROM eclipse-temurin:17-focal

--- a/build.clj
+++ b/build.clj
@@ -23,3 +23,15 @@
                           :src-dirs ["src"]
                           :ns-compile ['genegraph.main]))
     (b/uber        project)))
+
+(defn uber-repl [_]
+  ;; https://clojure.github.io/tools.build/clojure.tools.build.api.html#var-compile-clj
+  (let [{:keys [paths] :as basis} (b/create-basis (assoc defaults :aliases [:with-nrepl-deps]))
+        project                   (assoc defaults
+                                         :basis basis
+                                         :ns-compile ['genegraph.main-repl]
+                                         :main 'genegraph.main-repl)]
+    (b/delete      project)
+    (b/copy-dir    (assoc project :src-dirs paths))   ;; include all resource dirs in target/
+    (b/compile-clj (assoc project :src-dirs ["src"])) ;; but only compile src/
+    (b/uber        project)))

--- a/deps.edn
+++ b/deps.edn
@@ -60,6 +60,9 @@
     ;; REPL-y main function evalutes this.
     "-e" "(in-ns 'genegraph.main)"]}
 
+  :with-nrepl-deps
+  {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}}
+
   :genegraph-with-repl
   {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
    :main-opts ["-m" "genegraph.main-repl"]}

--- a/resources/kafka.edn
+++ b/resources/kafka.edn
@@ -37,7 +37,7 @@
                                        :cluster :dx-ccloud}
             :gene-tracker-test {:name "gt-precuration-events-test"
                                 :cluster :dx-ccloud}
-            :clinvar-raw {:name "clinvar-raw-dedup"
+            :clinvar-raw {:name "clinvar-raw"
                           :cluster :dx-ccloud
                           :format :clinvar-raw
                           :producer-topic :test-public-v1}

--- a/src/genegraph/main_repl.clj
+++ b/src/genegraph/main_repl.clj
@@ -1,5 +1,6 @@
 (ns genegraph.main-repl
   (:require [genegraph.main]
+            [io.pedestal.log :as log]
             [mount.core :as mount]
             [nrepl.server])
   (:gen-class))
@@ -11,5 +12,6 @@
   :stop (nrepl.server/stop-server nrepl-server))
 
 (defn -main [& args]
+  (log/info :msg "Starting nrepl server")
   (mount/start #'nrepl-server)
   (apply genegraph.main/-main args))

--- a/src/genegraph/main_repl.clj
+++ b/src/genegraph/main_repl.clj
@@ -8,10 +8,14 @@
 ;; https://cljdoc.org/d/nrepl/nrepl/1.0.0/doc/usage/server#_embedding_nrepl
 
 (mount/defstate nrepl-server
-  :start (nrepl.server/start-server :port 6000)
+  :start (nrepl.server/start-server :port (-> "GENEGRAPH_NREPL_PORT"
+                                              System/getenv
+                                              (or "6000")
+                                              parse-long))
   :stop (nrepl.server/stop-server nrepl-server))
 
 (defn -main [& args]
-  (log/info :msg "Starting nrepl server")
-  (mount/start #'nrepl-server)
+  (when (seq (System/getenv "GENEGRAPH_NREPL_PORT"))
+    (log/info :msg "Starting nrepl server")
+    (mount/start #'nrepl-server))
   (apply genegraph.main/-main args))

--- a/src/genegraph/main_repl.clj
+++ b/src/genegraph/main_repl.clj
@@ -8,14 +8,16 @@
 ;; https://cljdoc.org/d/nrepl/nrepl/1.0.0/doc/usage/server#_embedding_nrepl
 
 (mount/defstate nrepl-server
-  :start (nrepl.server/start-server :port (-> "GENEGRAPH_NREPL_PORT"
-                                              System/getenv
-                                              (or "6000")
-                                              parse-long))
-  :stop (nrepl.server/stop-server nrepl-server))
+  :start (when (System/getenv "GENEGRAPH_NREPL_PORT")
+           (log/info :msg "Starting nrepl server")
+           (nrepl.server/start-server :port (-> "GENEGRAPH_NREPL_PORT"
+                                                System/getenv
+                                                parse-long)
+                                    ;; Add host 127.0.0.1
+                                      ))
+  :stop (when nrepl-server
+          (nrepl.server/stop-server nrepl-server)))
 
 (defn -main [& args]
-  (when (seq (System/getenv "GENEGRAPH_NREPL_PORT"))
-    (log/info :msg "Starting nrepl server")
-    (mount/start #'nrepl-server))
+  (mount/start #'nrepl-server)
   (apply genegraph.main/-main args))

--- a/src/genegraph/migration.clj
+++ b/src/genegraph/migration.clj
@@ -16,18 +16,13 @@
             [mount.core :refer [start stop]]
             [clojure.java.shell :refer [sh]]
             [io.pedestal.log :as log])
-  (:import [java.time ZonedDateTime ZoneOffset]
-           java.time.format.DateTimeFormatter
-           [java.nio ByteBuffer]
-           [java.nio.file Path Paths]
-           [java.io InputStream OutputStream FileInputStream File]
-           [com.google.common.io ByteStreams]
-           [com.google.cloud.storage Bucket BucketInfo Storage StorageOptions
-                                     BlobId BlobInfo Blob]
-           [com.google.cloud.storage Storage$BlobWriteOption
-                                     Storage$BlobTargetOption
-                                     Storage$BlobSourceOption
-                                     Blob$BlobSourceOption]))
+  (:import (java.time ZonedDateTime ZoneOffset)
+           (java.time.format DateTimeFormatter)
+           (java.nio.file Paths)
+           (java.io FileInputStream)
+           (com.google.common.io ByteStreams)
+           (com.google.cloud.storage StorageOptions BlobId BlobInfo)
+           (com.google.cloud.storage Storage$BlobWriteOption)))
 
 (defn- new-version-identifier
   "Generate a new identifier for a migration"
@@ -119,11 +114,9 @@
 (defn get-version-id
   "Generates a version id string based on env/data-version (or a timestamp) plus the docker image version of the code"
   []
-  (let [data-version-id (if (some? env/data-version) env/data-version (new-version-identifier))
-        version-id (if (some? env/genegraph-image-version)
-                     (str data-version-id ":" env/genegraph-image-version)
-                     data-version-id)]
-    version-id))
+  (if (some? env/data-version)
+    env/data-version
+    (new-version-identifier)))
 
 (defn create-migration
   "Populate a new database, package and upload to Google Cloud"

--- a/src/genegraph/sink/stream.clj
+++ b/src/genegraph/sink/stream.clj
@@ -87,7 +87,7 @@
         partition-infos (.partitionsFor consumer topic-name)]
     (map #(TopicPartition. (.topic %) (.partition %)) partition-infos)))
 
-(defn- poll-catch-exception
+(defn poll-catch-exception
   "Performs periodic polling on consumer, returns a seq of consumed
   messages or :error on poll exception"
   [consumer]

--- a/src/genegraph/source/registry/redis.clj
+++ b/src/genegraph/source/registry/redis.clj
@@ -1,7 +1,8 @@
 (ns genegraph.source.registry.redis
   (:require [genegraph.rocksdb :as rocksdb]
             [io.pedestal.log :as log]
-            [taoensso.carmine :as car]))
+            [taoensso.carmine :as car]
+            [taoensso.carmine.connections :as car-conn]))
 
 ;; Carmine uses memoization to store the threadpool for each connection config.
 ;; This might leave dangling threads in the pool even when the application code
@@ -10,10 +11,18 @@
 ;; https://github.com/ptaoussanis/carmine/issues/266
 ;; Might be able to get the handle to the threadpool by calling
 ;; taoensso.carmine.connections/conn-pool.
-;; Might also be able to kick the threadpool out of hte memoize cache
+;; Might also be able to kick the threadpool out of the memoize cache
 ;; by sending the db spec with :mem/del as the first vararg.
 ;; http://ptaoussanis.github.io/encore/taoensso.encore.html#var-memoize
+;; Resolve with an explicitly defined threadpool:
+;; https://github.com/ptaoussanis/carmine/commit/a1d0c4ec1dd4848a9323eaa149ab284509664515
 
+
+(defn make-connection-pool
+  "connections/conn-pool supports :mem/del and :mem/fresh via encore/cache
+   https://github.com/ptaoussanis/encore/blob/0034c80e5caea4cf1d413c5eb918798761e40570/src/taoensso/encore.cljc#L2475"
+  [pool-opts]
+  (car-conn/conn-pool :mem/fresh pool-opts))
 
 (defn default-serializer
   "Takes a key of arbitrary data, return byte array (or maybe string).

--- a/src/genegraph/source/registry/redis.clj
+++ b/src/genegraph/source/registry/redis.clj
@@ -2,28 +2,7 @@
   (:require [genegraph.rocksdb :as rocksdb]
             [genegraph.transform.clinvar.common :refer [with-retries]]
             [io.pedestal.log :as log]
-            [taoensso.carmine :as car]
-            [taoensso.carmine.connections :as car-conn]))
-
-;; Carmine uses memoization to store the threadpool for each connection config.
-;; This might leave dangling threads in the pool even when the application code
-;; has finished. Should look into that.
-;; https://github.com/ptaoussanis/carmine/issues/224
-;; https://github.com/ptaoussanis/carmine/issues/266
-;; Might be able to get the handle to the threadpool by calling
-;; taoensso.carmine.connections/conn-pool.
-;; Might also be able to kick the threadpool out of the memoize cache
-;; by sending the db spec with :mem/del as the first vararg.
-;; http://ptaoussanis.github.io/encore/taoensso.encore.html#var-memoize
-;; Resolve with an explicitly defined threadpool:
-;; https://github.com/ptaoussanis/carmine/commit/a1d0c4ec1dd4848a9323eaa149ab284509664515
-
-
-(defn make-connection-pool
-  "connections/conn-pool supports :mem/del and :mem/fresh via encore/cache
-   https://github.com/ptaoussanis/encore/blob/0034c80e5caea4cf1d413c5eb918798761e40570/src/taoensso/encore.cljc#L2475"
-  [pool-opts]
-  (car-conn/conn-pool :mem/fresh pool-opts))
+            [taoensso.carmine :as car]))
 
 (defn default-serializer
   "Takes a key of arbitrary data, return byte array (or maybe string).
@@ -81,7 +60,6 @@
                     (with-retries 12 5000 #(car/wcar conn (car/scan cursor "COUNT" scan-count)))
                     next-cursor (parse-long next-cursor)]
                 (reset! total (+ @total (count rs)))
-                (println {:next-cursor next-cursor :rs-count (count rs) :total @total})
                 (cond-> rs
                   (not= 0 next-cursor)
                   (lazy-cat (get-batch next-cursor)))))]
@@ -98,11 +76,3 @@
   (wcar* (car/get "key1"))
 
   (wcar* (car/scan 0 "match" "key*")))
-
-(comment
-  #_(put-key conn "key1" "val1")
-
-  #_(time (dorun (pmap #(put-key conn (str "key" %) (str "val" %)) (range 1000))))
-  #_(time (def result-vals (car/wcar conn
-                                     (into '() (pmap #(get-key conn (str "key" %))
-                                                     (range 100)))))))

--- a/src/genegraph/source/registry/redis.md
+++ b/src/genegraph/source/registry/redis.md
@@ -29,3 +29,16 @@ docker run --rm --net host -it redis redis-cli -p 6378
 # Get db size increases over 100 seconds at 10 second intervals
 
 for i in $(seq 1 10); do nc -w 1 vrs-cache-redis-svc 6379 <<< DBSIZE; sleep 10; done
+
+
+# Port forwarding into a redis pod and connecting to it locally
+
+Port forward local 6380 to remote 6379
+```
+kubectl port-forward sts/vrs-cache-redis 6380:6379
+```
+
+Connect using redisredis docker image and docker-for-mac localhost hostname.
+```
+docker run -it --rm redis redis-cli -h docker.for.mac.localhost -p 6380
+```

--- a/src/genegraph/source/registry/vrs_registry.clj
+++ b/src/genegraph/source/registry/vrs_registry.clj
@@ -127,31 +127,35 @@
         topic-kw :clinvar-raw
         topic-name (-> stream/config :topics topic-kw :name)]
     (stream/initialize-current-offsets!) ; Reads partition_offsets.edn
-    (with-open [consumer (stream/assigned-consumer-for-topic topic-kw)]
-      (doseq [tp (.assignment consumer)]
-        (reset-consumer-position consumer tp))
-      (while (and @running-atom (<= (swap! batch-counter inc) batch-limit))
-        (when-let [batch (with-retries 60 (* 60 1000) ; 1 hr, retrying every 60 seconds
-                           #(let [pb (stream/poll-catch-exception consumer)]
-                              (if (= :error pb)
-                                (throw (ex-info "Exception in polling" {:assignment (.assignment consumer)}))
-                                pb)))]
-          (when (not-empty batch)
-            (let [time-start (Instant/now)]
-              (dorun
-               (->> batch
-                    (map #(stream/consumer-record-to-event % topic-kw))
-                    (event-processing-fn-batched thread-pool)
-                    (filter #(:exception %))
-                    (map #(log/error :fn ::-main :event-with-exception %))))
-              (let [batch-duration (Duration/between time-start (Instant/now))]
-                (log/info :fn ::-main
-                          :batch-start (some-> batch first .offset)
-                          :batch-end (some-> batch last .offset)
-                          :batch-size (.count batch)
-                          :batch-duration (.toString batch-duration)
-                          :time-per-event (.toString (.dividedBy batch-duration (long (.count batch))))))))
-          (stream/update-consumer-offsets! consumer [(TopicPartition. topic-name 0)]))))))
+    (with-retries 60 (* 60 1000) ; 60 1min retries
+      (fn []
+        (when @running-atom ; Returning nil will short-circuit with-retries
+          (log/info :fn ::-main :msg "Opening consumer")
+          (with-open [consumer (stream/assigned-consumer-for-topic topic-kw)]
+            (doseq [tp (.assignment consumer)]
+              (reset-consumer-position consumer tp))
+            (while (and @running-atom (<= (swap! batch-counter inc) batch-limit))
+              (when-let [batch (with-retries 60 (* 60 1000) ; 60 1min retries
+                                 #(let [pb (stream/poll-catch-exception consumer)]
+                                    (if (= :error pb)
+                                      (throw (ex-info "Exception in polling" {:assignment (.assignment consumer)}))
+                                      pb)))]
+                (when (not-empty batch)
+                  (let [time-start (Instant/now)]
+                    (dorun
+                     (->> batch
+                          (map #(stream/consumer-record-to-event % topic-kw))
+                          (event-processing-fn-batched thread-pool)
+                          (filter #(:exception %))
+                          (map #(log/error :fn ::-main :event-with-exception %))))
+                    (let [batch-duration (Duration/between time-start (Instant/now))]
+                      (log/info :fn ::-main
+                                :batch-start (some-> batch first .offset)
+                                :batch-end (some-> batch last .offset)
+                                :batch-size (.count batch)
+                                :batch-duration (.toString batch-duration)
+                                :time-per-event (.toString (.dividedBy batch-duration (long (.count batch))))))))
+                (stream/update-consumer-offsets! consumer [(TopicPartition. topic-name 0)])))))))))
 
 
 #_(def redis-opts {:spec {:uri "redis://localhost:6380"}})

--- a/src/genegraph/transform/clinvar/cancervariants.clj
+++ b/src/genegraph/transform/clinvar/cancervariants.clj
@@ -46,12 +46,7 @@
 ;; but really all we need is the expression -> variation object cached.
 ;; each normalization function may use a slightly different expr specification, so each
 ;; should define their own key fn for how the expr is deterministically serialized.
-;; (def vicc-db-name "cancervariants-cache.db")
 (def vicc-expr-db-name "cancervariants-expr-cache.db")
-
-;; (mount/defstate ^RocksDB vicc-expr-db
-;;   :start (rocksdb/open vicc-expr-db-name)
-;;   :stop (rocksdb/close vicc-expr-db))
 
 (defn normalize-canonical
   "Normalizes an :hgvs or :spdi expression.
@@ -114,27 +109,6 @@
    Note: nil .spec values defaults to 127.0.0.1:6379"
   {:pool {#_(comment Default pool options)}
    :spec {:uri (System/getenv "CACHE_REDIS_URI")}})
-
-(comment
-  "I had thought the carmine connection pool might be leaving dangling threads
-   but after investigating a bit it doesn't seem like it is.
-   Can delete this."
-  (mount/defstate redis-db
-    ;; :pool-fn #(redis/make-connection-pool {#_(comment Default pool options)})
-    :start (if (redis/connectable? redis-opts)
-             (assoc redis-opts :pool ((:pool-fn redis-opts)))
-             (throw (ex-info "Could not connect to redis"
-                             {:conn-opts redis-opts})))
-   ;; TODO test that this .close actually terminates the connections that are idle
-   ;; Look at threads
-   ;; https://stackoverflow.com/a/3018672/2172133
-   ;; Potentially tweak pool options:
-    #_{:time-between-eviction-runs-ms 1000
-       :min-evictable-idle-time-ms 1000
-       :test-on-borrow? true
-       :test-on-return? true
-       :test-while-idle? true}
-    :stop (.close (:pool redis-db))))
 
 (defn redis-configured? []
   (System/getenv "CACHE_REDIS_URI"))

--- a/src/genegraph/transform/clinvar/clinical_assertion.clj
+++ b/src/genegraph/transform/clinvar/clinical_assertion.clj
@@ -539,6 +539,15 @@
      :is_reported_in (let [doc-resource (q/ld1-> method-resource [:vrs/is_reported_in])]
                        (document-resource-for-output doc-resource))}))
 
+(defn extension-resource-for-output
+  [extension-resource]
+  (when extension-resource
+    (common/map-pop-out-lone-seq-values
+     {:type (q/ld1-> extension-resource [:rdf/type])
+      :name (q/ld1-> extension-resource [:vrs/name])
+      :value (map #(-> % common/rdf-select-tree common/map-unnamespace-property-kw-keys)
+                  (q/ld-> extension-resource [:rdf/value]))})))
+
 (defn clinical-assertion-resource-for-output
   ;; TODO remove keys with nil values
   ;; TODO handle :event_type delete for all these records.
@@ -553,6 +562,11 @@
         subject-descriptor (variation-descriptor-by-clinvar-id
                             (q/ld1-> assertion-resource [:vrs/subject-descriptor])
                             release-date)]
+    (when (nil? subject-descriptor)
+      (log/warn :fn :clinical-assertion-resource-for-output
+                :msg (str/join " " ["No subject descriptor found."
+                                    "This could be because the variant for this assertion"
+                                    "has not been loaded yet."])))
     {:id (str assertion-resource)
      :type (q/ld1-> assertion-resource [:rdf/type])
      :label (q/ld1-> assertion-resource [:rdfs/label])
@@ -574,7 +588,9 @@
                              (q/ld1-> [:vrs/target-proposition])
                              (proposition-resource-for-output
                               (q/ld1-> subject-descriptor [:vrs/canonical_variation])
-                              release-date))}))
+                              release-date))
+     :extensions (->> (q/ld-> assertion-resource [:vrs/extensions])
+                      (map extension-resource-for-output))}))
 
 (defn add-data-for-clinical-assertion [event]
   (let [message (:genegraph.transform.clinvar.core/parsed-value event)
@@ -589,7 +605,13 @@
           :type stmt-type
           :label (:title assertion)
           ;; TODO
-          ;;:extensions nil
+          ;; https://github.com/clingen-data-model/genegraph/issues/697
+          :extensions (let [local-key (get assertion :local_key)]
+                        (log/info :fn :add-data-for-clinical-assertion
+                                  :local-key local-key
+                                  :assertion assertion)
+                        (common/fields-to-extension-maps
+                         (select-keys assertion [:local_key])))
           :description (description event)
           :method (method event)
           :contributions (contributions event)
@@ -608,7 +630,10 @@
           :target_proposition (proposition event)}
          :genegraph.annotate/iri
          (str (ns-cg "clinical_assertion_") (:id assertion) "." (:release_date message)))
-        add-contextualized)))
+        add-contextualized
+        (#(do (log/info :fn :clinical-assertion-contextualized-data
+                        :data (:genegraph.annotate/data-contextualized %))
+              %)))))
 
 
 (def statement-context

--- a/src/genegraph/transform/clinvar/clinical_assertion.clj
+++ b/src/genegraph/transform/clinvar/clinical_assertion.clj
@@ -587,7 +587,7 @@
      :target_proposition (-> assertion-resource
                              (q/ld1-> [:vrs/target-proposition])
                              (proposition-resource-for-output
-                              (q/ld1-> subject-descriptor [:vrs/canonical_variation])
+                              (some-> subject-descriptor (q/ld1-> [:vrs/canonical_variation]))
                               release-date))
      :extensions (->> (q/ld-> assertion-resource [:vrs/extensions])
                       (map extension-resource-for-output))}))

--- a/src/genegraph/transform/clinvar/common.clj
+++ b/src/genegraph/transform/clinvar/common.clj
@@ -520,13 +520,13 @@ LIMIT 1")
     (let [[ran? ret]
           (try [true (body-fn)]
                (catch Exception e
-                 (if (= 0 remaining-retries)
-                   (do (log/error :fn :with-retries :msg "Retry limit exceeded")
-                       (throw e))
-                   (do (log/info :fn :with-retries
-                                 :msg (format "body-fn failed, trying again in %s ms"
-                                              retry-interval-ms))
-                       (Thread/sleep retry-interval-ms)))))]
+                 (when (zero? remaining-retries)
+                   (log/error :fn :with-retries :msg "Retry limit exceeded")
+                   (throw e))
+                 (log/info :fn :with-retries
+                           :msg (format "body-fn failed, trying again in %s ms"
+                                        retry-interval-ms))
+                 (Thread/sleep retry-interval-ms)))]
       (if ran?
         ret
         (recur (dec retry-count))))))

--- a/src/genegraph/transform/clinvar/common.clj
+++ b/src/genegraph/transform/clinvar/common.clj
@@ -1,7 +1,6 @@
 (ns genegraph.transform.clinvar.common
   (:require [clojure.data.csv :as csv]
             [clojure.java.io :as io]
-            [clojure.pprint :refer [pprint]]
             [clojure.string :as str]
             [genegraph.database.load :as l]
             [genegraph.database.names :as names]
@@ -513,3 +512,21 @@ LIMIT 1")
             (when (not (nil? v))
               (vector k v)))]
     (replace-kvs input-map mutator)))
+
+(defn with-retries
+  "Tries to execute body-fn retry-count times."
+  [retry-count retry-interval-ms body-fn]
+  (loop [remaining-retries retry-count]
+    (let [[ran? ret]
+          (try [true (body-fn)]
+               (catch Exception e
+                 (if (= 0 remaining-retries)
+                   (do (log/error :fn :with-retries :msg "Retry limit exceeded")
+                       (throw e))
+                   (do (log/info :fn :with-retries
+                                 :msg (format "body-fn failed, trying again in %s ms"
+                                              retry-interval-ms))
+                       (Thread/sleep retry-interval-ms)))))]
+      (if ran?
+        ret
+        (recur (dec retry-count))))))

--- a/src/genegraph/transform/clinvar/core.clj
+++ b/src/genegraph/transform/clinvar/core.clj
@@ -68,9 +68,9 @@
     (-> event
         ;; Construct an empty model so downstream interceptors that try to read it dont get NPE
         (assoc ::q/model (l/statements-to-model []))
-        (update :exception conj {:fn :add-model-from-contextualized-data
-                                 :msg "Event did not have contextualized data"
-                                 :entity-type (-> event :genegraph.transform.clinvar/format)}))))
+        (update :warning conj {:fn :add-model-from-contextualized-data
+                               :msg "Event did not have contextualized data"
+                               :entity-type (-> event :genegraph.transform.clinvar/format)}))))
 
 (defmethod add-model :clinvar-raw
   [event]

--- a/src/genegraph/transform/clinvar/core.clj
+++ b/src/genegraph/transform/clinvar/core.clj
@@ -20,6 +20,12 @@
              (json/parse-string true)
              (util/parse-nested-content))))
 
+(def data-fns-for-type
+  {"trait" #(clinical-assertion/add-data-for-trait %)
+   "trait_set" #(clinical-assertion/add-data-for-trait-set %)
+   "clinical_assertion" #(clinical-assertion/add-data-for-clinical-assertion %)
+   "variation" #(variation/add-data-for-variation %)})
+
 (defmethod xform-types/add-data :clinvar-raw [event]
   (log/debug :fn :add-data)
   (try
@@ -31,17 +37,9 @@
                        :id (get-in event-with-json [::parsed-value :content :id]
                                    (get-in event-with-json [::parsed-value :content]))
                        :release_date (get-in event-with-json [::parsed-value :release_date]))
-          event-with-data (case (get-in event-with-json
-                                        [::parsed-value :content :entity_type])
-                            "trait" (clinical-assertion/add-data-for-trait
-                                     event-with-json)
-                            "trait_set" (clinical-assertion/add-data-for-trait-set
-                                         event-with-json)
-                            "clinical_assertion" (clinical-assertion/add-data-for-clinical-assertion
-                                                  event-with-json)
-                            "variation" (variation/add-data-for-variation
-                                         event-with-json)
-                            event-with-json)]
+          event-with-data (let [entity-type (get-in event-with-json [::parsed-value :content :entity_type])
+                                add-data-fn (get data-fns-for-type entity-type identity)]
+                            (add-data-fn event-with-json))]
       event-with-data)
     (catch Exception e
       (log/error :fn ::add-data :msg "Exception caught in add-data for :clinvar-raw"
@@ -68,9 +66,13 @@
     (-> event
         ;; Construct an empty model so downstream interceptors that try to read it dont get NPE
         (assoc ::q/model (l/statements-to-model []))
-        (update :warning conj {:fn :add-model-from-contextualized-data
-                               :msg "Event did not have contextualized data"
-                               :entity-type (-> event :genegraph.transform.clinvar/format)}))))
+        ;; Add a warning if this type has a transformer registered but no data was added
+        (#(let [entity-type (get-in % [::parsed-value :content :entity_type])]
+            (cond-> %
+              (data-fns-for-type entity-type)
+              (update :warning conj {:fn :add-model-from-contextualized-data
+                                     :msg "Event did not have contextualized data"
+                                     :entity-type (-> % :genegraph.transform.clinvar/format)})))))))
 
 (defmethod add-model :clinvar-raw
   [event]

--- a/src/genegraph/transform/clinvar/ga4gh.clj
+++ b/src/genegraph/transform/clinvar/ga4gh.clj
@@ -5,8 +5,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.stacktrace :refer [print-stack-trace]]
             [genegraph.annotate :as ann]
-            [genegraph.database.names :refer [prefix-ns-map]]
-            [genegraph.database.names :as names]
+            [genegraph.database.names :as names :refer [prefix-ns-map]]
             [genegraph.database.query :as q]
             [genegraph.database.util :refer [tx write-tx]]
             [genegraph.server]
@@ -32,7 +31,7 @@
   (mount/start
    #'genegraph.database.instance/db
    #'genegraph.database.property-store/property-store
-   #'genegraph.transform.clinvar.cancervariants/vicc-expr-db
+   #'genegraph.transform.clinvar.cancervariants/cache-db
    #'genegraph.sink.event-recorder/event-database))
 
 (defn eventify [input-map]

--- a/src/genegraph/transform/clinvar/ga4gh.clj
+++ b/src/genegraph/transform/clinvar/ga4gh.clj
@@ -12,10 +12,11 @@
             [genegraph.server]
             [genegraph.sink.event :as event]
             [genegraph.transform.clinvar.clinical-assertion :as ca]
-            [genegraph.transform.clinvar.common :as common :refer [replace-kvs
-                                                                   map-rdf-resource-values-to-str
-                                                                   map-unnamespace-values
-                                                                   map-compact-namespaced-values]]
+            [genegraph.transform.clinvar.common
+             :as common
+             :refer [map-compact-namespaced-values
+                     map-rdf-resource-values-to-str
+                     map-unnamespace-values]]
             [genegraph.transform.clinvar.core :refer [add-parsed-value]]
             [genegraph.transform.clinvar.iri :refer [ns-cg]]
             [genegraph.transform.clinvar.util :as util]

--- a/src/genegraph/transform/clinvar/variation.clj
+++ b/src/genegraph/transform/clinvar/variation.clj
@@ -265,6 +265,7 @@
   (let [vrs-obj (vicc/vrs-variation-for-expression
                  (-> expression)
                  (-> expression-type keyword))]
+    (log/debug :fn :get-vrs-variation-map :vrs-obj vrs-obj)
     (if (empty? vrs-obj)
       (let [e (ex-info "No variation received from VRS normalization" {:fn :add-vrs-model :expression expression})]
         (log/error :message (ex-message e) :data (ex-data e))
@@ -349,7 +350,8 @@
       (log/error :fn :normalize-canonical-expression
                  :message "Exception normalizing canonical variation"
                  :ex-data (ex-data e)
-                 :ex-message (ex-message e))
+                 :ex-message (ex-message e)
+                 :ex-stacktrace (with-out-str (clojure.stacktrace/print-stack-trace e)))
       (update event :exception conj {:fn :normalize-canonical-expression
                                      :message "Exception normalizing canonical variation"
                                      :exception e}))))


### PR DESCRIPTION
Included:
- Add more exception handling to vrs-cache mode. Network errors for redis, KafkaConsumer poll, or KafkaConsumer heartbeat should all be retried now
- Add ability to start an nrepl server by defining `GENEGRAPH_NREPL_PORT` 
- Add a build.clj target to build the uberjar with the nrepl functionality. If old `uber` target is used, uberjar will exclude this functionality altogether.
- Remove the potential use of `GENEGRAPH_IMAGE_VERSION` in the version-id used for migration file name building (was not used by current migration jobs).
- Add a function to scrape the VRS redis db and show the count of each `Variation` subtype