### PR TITLE
Fixing text/null variants that should have been otherwise

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -18,8 +18,7 @@
 
 
   :main-dev
-  {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
-                cider/cider-nrepl {:mvn/version,"0.28.5"}}
+  {:extra-deps {cider/cider-nrepl {:mvn/version,"0.28.5"}}
    :main-opts ["-e" "(require 'genegraph.main-repl)"
                "-m" "nrepl.cmdline"
                "--middleware" "[cider.nrepl/cider-middleware]"]}
@@ -70,23 +69,6 @@
     "-m" "reply.main"
     ;; REPL-y main function evalutes this.
     "-e" "(in-ns 'genegraph.main)"]}
-
-  :with-nrepl-deps
-  {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}}
-
-  :genegraph-with-repl
-  {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
-   :main-opts ["-m" "genegraph.main-repl"]}
-
-  ;; Starts an nREPL server on port 6000. Pre-compiles the genegraph.server ns.
-  ;; There's a problem with all output not being sent to client.
-  :repl-server
-  {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
-   :main-opts
-   ["-e" "(require 'genegraph.server)"
-    "-m" "nrepl.cmdline"
-    "--host" "127.0.0.1"
-    "--port" "6000"]}
 
   :run                                  ; This doesn't work yet.
   {:extra-deps  {io.pedestal/pedestal.service-tools {:mvn/version "0.5.5"}}

--- a/src/genegraph/main.clj
+++ b/src/genegraph/main.clj
@@ -82,6 +82,6 @@
       (run-server-transformer nil)
       (run-server-genegraph nil))
     (cond
-      (= "snapshot" (first args)) (apply snapshot/-main2 (rest args))
+      (= "snapshot" (first args)) (apply snapshot/-main (rest args))
       (= "vrs-cache" (first args)) (apply vrs-registry/-main (rest args))
       :else (run-migration))))

--- a/src/genegraph/transform/clinvar/cancervariants.clj
+++ b/src/genegraph/transform/clinvar/cancervariants.clj
@@ -24,7 +24,7 @@
 
 (def url-absolute-cnv
   "URL for cancervariants.org Absolute Copy Number normalization."
-  (str variation-normalizer-base-url "/parsed_to_abs_cnv"))
+  (str variation-normalizer-base-url "/parsed_to_cn_var"))
 
 (def url-relative-cnv
   "URL for cancervariants.org Relative Copy Number normalization."
@@ -126,8 +126,8 @@
         status (:status response)]
     (cond
       (= status 200) (let [body (-> response :body json/parse-string)]
-                       (when (get body "absolute_copy_number")
-                         (-> body (get "absolute_copy_number") add-vicc-context)))
+                       (when (get body "copy_number_count")
+                         (-> body (get "copy_number_count") add-vicc-context)))
       :else (log/error :msg "Error in VRS normalization request"
                        :fn :normalize-absolute-copy-number
                        :input-map input-map

--- a/src/genegraph/transform/clinvar/variation.clj
+++ b/src/genegraph/transform/clinvar/variation.clj
@@ -394,11 +394,15 @@
                              {:expression (-> event ::prioritized-expression :expr)
                               :expression-type (-> event ::prioritized-expression :type)})
                             :variation)
-                       (get (get-vrs-variation-map
-                             {:expression (str "clinvar:" (get-in event [:genegraph.transform.clinvar.core/parsed-value
-                                                                         :content
-                                                                         :id]))
-                              :expression-type :text})
+                       (get (let [clinvar-id (get-in event [:genegraph.transform.clinvar.core/parsed-value
+                                                            :content
+                                                            :id])
+                                  ret (get-vrs-variation-map
+                                       {:expression (str "clinvar:" clinvar-id)
+                                        :expression-type :text})]
+                              (log/info :msg "Fell back to Text for CNV" :clinvar-id clinvar-id
+                                        :expression (-> event ::prioritized-expression))
+                              ret)
                             :variation))
        :label (-> event ::prioritized-expression :expr)}
       (let [prefiltered-candidate-expressions (::canonical-candidate-expressions event)
@@ -448,7 +452,6 @@
                     :msg "Removed some deldup candidate expressions"
                     :removed (set/difference (set prefiltered-candidate-expressions)
                                              (set candidate-expressions))))
-
         (log/debug :candidate-expressions candidate-expressions)
         ;; each vrs-ret[:variation] is the structure in the 'variation', 'canonical_variaton' (or equivalent)
         ;; field in the normalization service response body

--- a/src/genegraph/transform/clinvar/variation.clj
+++ b/src/genegraph/transform/clinvar/variation.clj
@@ -68,13 +68,12 @@
             (get-spdi [nested-content]
               (-> nested-content (get "CanonicalSPDI") (get "$")))
             (get-sequence-location [nested-content sequence-accession]
-              (log/info :nested-content nested-content
-                        :sequence-accession sequence-accession)
+              (log/debug :nested-content nested-content
+                         :sequence-accession sequence-accession)
               (->> (get-in nested-content ["Location" "SequenceLocation"])
                    util/into-sequential-if-not
                    (filter #(= sequence-accession (get % "@Accession")))
-                   first
-                   (#(do (log/info :location %) %))))]
+                   first))]
       (let [exprs (for [val-opt [{:fn #(get-spdi nested-content)
                                   :type :spdi
                                   :label "SPDI"}
@@ -261,7 +260,7 @@
                Must be called *after* try-absolute-copy-number"
               (let [hgvs-exprs (->> prioritized-expressions
                                     (filter #(= :hgvs (:type %))))]
-                (log/info :variation-type variation-type :hgvs-exprs hgvs-exprs)
+                (log/debug :variation-type variation-type :hgvs-exprs hgvs-exprs)
                 (if (and (not-empty hgvs-exprs)
                          (or (and (.startsWith variation-type "copy number")
                                   (not (::cnv event)))

--- a/src/genegraph/transform/clinvar/variation.clj
+++ b/src/genegraph/transform/clinvar/variation.clj
@@ -345,13 +345,9 @@
              :expression expression
              :syntax syntax
              :syntax-version syntax-version)
-  ;;member-iri (l/blank-node)
-  ;;expression-iri (l/blank-node)
-  {;;:id member-iri
-   :type "VariationMember"
+  {:type "VariationMember"
    :expressions [(merge
-                  {;;expression-iri
-                   :type "Expression"
+                  {:type "Expression"
                    :syntax syntax
                    :value expression}
                   (when syntax-version
@@ -369,7 +365,8 @@
                  (-> expression-type keyword))]
     (log/debug :fn :get-vrs-variation-map :vrs-obj vrs-obj)
     (if (empty? vrs-obj)
-      (let [e (ex-info "No variation received from VRS normalization" {:fn :add-vrs-model :expression expression})]
+      (let [e (ex-info "No variation received from VRS normalization"
+                       {:fn :add-vrs-model :input inp})]
         (log/error :message (ex-message e) :data (ex-data e)))
       (let [vrs-obj-pretty (-> vrs-obj
                                (recursive-replace-keys
@@ -401,7 +398,7 @@
                              {:expression (str "clinvar:" (get-in event [:genegraph.transform.clinvar.core/parsed-value
                                                                          :content
                                                                          :id]))
-                              :expression-type :hgvs})
+                              :expression-type :text})
                             :variation))
        :label (-> event ::prioritized-expression :expr)}
       (let [prefiltered-candidate-expressions (::canonical-candidate-expressions event)
@@ -449,12 +446,6 @@
         (when (not= candidate-expressions prefiltered-candidate-expressions)
           (log/warn :fn :normalize-canonical-expression
                     :msg "Removed some deldup candidate expressions"
-
-                    #_#_:removed (set/difference (set candidate-expressions)
-                                                 (set prefiltered-candidate-expressions))
-
-                    ;; TODO why not set/difference?
-                    ;; (set/difference (set candidate-expressions) (set prefiltered-candidate-expressions))
                     :removed (set/difference (set prefiltered-candidate-expressions)
                                              (set candidate-expressions))))
 

--- a/src/genegraph/transform/clinvar/vrs_analysis.clj
+++ b/src/genegraph/transform/clinvar/vrs_analysis.clj
@@ -1,16 +1,21 @@
 (ns genegraph.transform.clinvar.vrs-analysis
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
+            [clojure.string :as str]
+            [com.climate.claypoole :as cp]
             [genegraph.rocksdb :as rocksdb]
             [genegraph.sink.event :as ev]
             [genegraph.source.snapshot.core :as snapshot]
-            [clojure.string :as str]
+            [genegraph.transform.clinvar.cancervariants :as vicc]
+            [genegraph.transform.clinvar.ga4gh :as ga4gh]
             [io.pedestal.log :as log]
-            [me.raynes.fs :as fs]
-            [genegraph.transform.clinvar.ga4gh :as ga4gh]))
+            [me.raynes.fs :as fs]))
 
 
-(def files (mapv #(.getPath %) (fs/list-dir "vrs_analysis")))
+#_(def files (mapv #(.getPath %) (fs/list-dir "vrs_analysis")))
+
+;; "Elapsed time: 2464946.621451 msecs"
+(def files (mapv #(.getPath %) (fs/list-dir "vrs_analysis_v2")))
 
 (defn clinvar-raw-ize
   [bigquery-json-record]
@@ -47,38 +52,42 @@
 
 (defn process-file [filename]
   (with-open [reader (io/reader filename)
-              #_#_error-log (io/writer "errors.txt")]
-    (let [limit Long/MAX_VALUE
-          line-count (atom 0)]
-      (doseq [[i event] (->> (line-seq reader)
-                             (take limit)
-                             (map (fn [line]
-                                    (-> line
-                                        json/parse-string
-                                        (assoc "entity_type" "variation")
-                                        clinvar-raw-ize
-                                        eventify)))
-                             (pmap (fn [event]
-                                     (->  event
-                                          (assoc ::ev/interceptors snapshot/interceptor-chain)
-                                          (snapshot/process-event-catch-exceptions))))
-                             (map-indexed vector))]
-        (log/debug :data (:genegraph.annotate/data event))
-        (log/debug :id (get-in event [:genegraph.annotate/data :id])
-                   :description (get-in event [:genegraph.annotate/data :description]))
-        (swap! line-count inc)
-        (when (not (:genegraph.annotate/data event))
-          (log/error :msg "Data not added to event" :event event))
-        (when (= 0 (rem i 1000))
-          (log/info :progress i))))))
+              #_#_error-log (io/writer "errors.txt")
+              data-writer (io/writer "data.ndedn")]
+    (cp/with-shutdown! [threadpool (cp/threadpool 10)]
+      (let [limit Long/MAX_VALUE
+            line-count (atom 0)]
+        (doseq [[i event] (->> (line-seq reader)
+                               (take limit)
+                               (map (fn [line]
+                                      (-> line
+                                          json/parse-string
+                                          (assoc "entity_type" "variation")
+                                          clinvar-raw-ize
+                                          eventify)))
+                               (cp/pmap threadpool
+                                        (fn [event]
+                                          (->  event
+                                               (assoc ::ev/interceptors snapshot/interceptor-chain)
+                                               (snapshot/process-event-catch-exceptions))))
+                               (map-indexed vector))]
+          (log/debug :data (:genegraph.annotate/data event))
+          (log/debug :id (get-in event [:genegraph.annotate/data :id])
+                     :description (get-in event [:genegraph.annotate/data :description]))
+          (swap! line-count inc)
+          (if (not (:genegraph.annotate/data event))
+            (log/error :msg "Data not added to event" :event (dissoc event :exceptions))
+            (.write data-writer (prn-str (:genegraph.annotate/data event))))
+
+          (when (= 0 (rem i 1000))
+            (log/info :progress i)))
+        (log/info :line-count @line-count)))))
 
 (defn -main []
   (snapshot/start-states!)
-  (let [line-count (atom 0)]
-    (doseq [fname (->> files
-                       (take 1))]
-      (log/info :fname fname)
-      (process-file fname))))
+  (doseq [fname (->> files)]
+    (log/info :fname fname)
+    (process-file fname)))
 
 (comment
   (def written-datasets (snapshot/snapshot-write snapshot/snapshot-datasets)))
@@ -95,6 +104,44 @@
           (rocksdb/entire-db-seq (var-get db-var)))
   ())
 
+(def thread-pool (cp/threadpool 50))
+
+(defn test-long
+  "
+   with daphne on server: 4053.801761 msecs
+   with gunicorn with 4 workers: 4142.269335 msecs (warning)
+   with uvicorn directly: 3735.313562 msecs
+
+   gunicorn warnings:
+   [2023-05-03 22:20:45 +0000] [266] [WARNING] Unsupported upgrade request.
+[2023-05-03 22:20:45 +0000] [266] [WARNING] No supported WebSocket library detected. Please use \"pip install 'uvicorn[standard]'\", or install 'websockets' or 'wsproto' manually.
+
+   still hangs: NC_000021.8:g.14714507_29216662dup
+   NC_000011.9:g.104288964_134937416dup
+   NC_000015.9:g.31115047_102354857dup
+   NC_000020.10:g.17705775_31600738dup
+   "
+  []
+  (let [exprs (repeat 100 "NC_000001.10:g.(?_147230250)_(147231366_?)dup")]
+    (->> exprs
+         (map (fn [exp]
+                {:hgvs {:expr exp
+                        :copy-class "Duplication"}}))
+         (cp/pmap
+          thread-pool
+          genegraph.transform.clinvar.cancervariants/normalize-relative-copy-number)
+         #_(map genegraph.transform.clinvar.cancervariants/normalize-relative-copy-number)
+         doall)
+    #_(->> exprs
+           (map (fn [exp]
+                  {:hgvs {:expr exp
+                          :copy-class "Duplication"}}))
+           (map genegraph.transform.clinvar.cancervariants/normalize-relative-copy-number)
+           (cp/pmap pool identity)
+           doall)))
+
+(comment
+  {:counters {"CopyNumberChange" 23901, "Text" 6933, "Allele" 7, nil 2}, :line 192})
 
 (defn count-variation-types []
   (with-open [writer-allele (io/writer "variation-allele.txt")
@@ -148,3 +195,30 @@
               (log/info :counters @counters)))))
       (log/info :counters @counters)
       counters)))
+
+(with-open [reader (io/reader "vrs_analysis_v2/000000000000")]
+  (->> (line-seq reader)
+       (map #(json/parse-string % true))))
+
+(comment
+  "problem variant:"
+  '{:fn :normalize-relative-copy-number,
+    :expr "NC_000017.11:g.43070192_43078360dup",
+    :copy-class "Duplication",
+
+    :efo-copy-class "efo:0030070", :line 144}
+
+  (genegraph.transform.clinvar.cancervariants/normalize-relative-copy-number
+   {:hgvs {:expr "NC_000017.11:g.43070192_43078360dup"
+           :copy-class "Duplication"}})
+
+  (last
+   (cp/pmap thread-pool
+            (fn [_]
+              (genegraph.transform.clinvar.cancervariants/normalize-relative-copy-number
+               {:hgvs {:expr "NC_000017.11:g.43070192_43078360dup"
+                       :copy-class "Duplication"}}))
+            (range 1000)))
+
+
+  ())


### PR DESCRIPTION
There were previously some CNVs that should have been normalized to CNV instead of Text given current capabilities of the normalization service. 

Some will remain as Text until these are resolved:
- definite range CopyNumberCounts
   - https://github.com/clingen-data-model/genegraph/issues/707
- copy numbers with one endpoint being a range and the other being a number
   - https://github.com/cancervariants/variation-normalization/issues/417
  
Resolves https://github.com/clingen-data-model/genegraph/issues/748

Touches https://github.com/clingen-data-model/genegraph/issues/698